### PR TITLE
Implement skorch interface NeuralNetTorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ Thumbs.db
 
 # coverage
 .coverage
+
+# PyCharm settings
+.idea/
+
+# macOS custom attributes file
+*.DS_Store
+
+# VScode settings
+.vscode/

--- a/autoemulate/emulators/__init__.py
+++ b/autoemulate/emulators/__init__.py
@@ -19,6 +19,6 @@ MODEL_REGISTRY = {
     "SupportVectorMachines": SupportVectorMachines,
     "XGBoost": XGBoost,
     "NeuralNetSk": NeuralNetSk,
-    # "NeuralNetTorch": NeuralNetTorch,
+    "NeuralNetTorch": NeuralNetTorch,
     # "GaussianProcess": GaussianProcess,
 }

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -168,7 +168,16 @@ class NeuralNetTorch(NeuralNetRegressor):
         return hasattr(self, "n_features_in_")
 
     def _more_tags(self):
-        return {"multioutput": True, "poor_score": True}
+        return {
+            "multioutput": True,
+            "poor_score": True,
+            "_xfail_checks": {
+                "check_no_attributes_set_in_init": "skorch initialize attributes in __init__.",
+                "check_regressors_no_decision_function": "skorch NeuralNetRegressor class implements the predict_proba.",
+                "check_parameters_default_constructible": "skorch NeuralNet class callbacks parameter expects a list of callables.",
+                "check_dont_overwrite_parameters": "the change of public attribute module__input_size is needed to support dynamic input size.",
+            },
+        }
 
     def check_data(self, X: np.ndarray, y: np.ndarray = None):
         if isinstance(y, np.ndarray):

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -4,16 +4,15 @@
 
 import random
 import warnings
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
-import skorch
 import torch
 from scipy.sparse import issparse
 from scipy.stats import loguniform
 from sklearn.exceptions import DataConversionWarning
 from skopt.space import Integer, Real
-from skorch import NeuralNet, NeuralNetRegressor
+from skorch import NeuralNetRegressor
 from skorch.callbacks import Callback
 from torch import nn
 
@@ -38,7 +37,7 @@ class InputShapeSetter(Callback):
 
     def on_train_begin(
         self,
-        net,
+        net: NeuralNetRegressor,
         X: torch.Tensor | np.ndarray = None,
         y: torch.Tensor | np.ndarray = None,
         **kwargs,

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -143,7 +143,7 @@ class NeuralNetTorch(NeuralNetRegressor):
         param_grid_random = {
             "lr": loguniform(1e-4, 1e-2),
             "max_epochs": [10, 20, 30],
-            "module__hidden_layer_sizes": [
+            "module__hidden_sizes": [
                 (50,),
                 (100,),
                 (100, 50),

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -3,13 +3,16 @@
 # but doesn't pass tests, because we're subclassing
 
 import random
+from typing import List, Tuple
 
 import numpy as np
 import skorch
 import torch
+from scipy.sparse import issparse
 from scipy.stats import loguniform
 from skopt.space import Integer, Real
 from skorch import NeuralNet, NeuralNetRegressor
+from skorch.callbacks import Callback
 from torch import nn
 
 
@@ -28,7 +31,7 @@ def set_random_seed(seed: int, deterministic: bool = False):
         torch.use_deterministic_algorithms(True)
 
 
-class InputShapeSetter(skorch.callbacks.Callback):
+class InputShapeSetter(Callback):
     """Callback to set input and output layer sizes dynamically."""
 
     def on_train_begin(
@@ -38,58 +41,59 @@ class InputShapeSetter(skorch.callbacks.Callback):
         y: torch.Tensor | np.ndarray = None,
         **kwargs,
     ):
-        output_size = 1 if y.ndim == 1 else y.shape[1]
-        net.set_params(module__input_size=X.shape[1], module__output_size=output_size)
+        if hasattr(net, "n_features_in_") and net.n_features_in_ != X.shape[-1]:
+            raise ValueError(
+                f"Mismatch number of features, "
+                f"expected {net.n_features_in_}, received {X.shape[-1]}."
+            )
+        if not hasattr(net, "n_features_in_"):
+            output_size = 1 if y.ndim == 1 else y.shape[1]
+            net.set_params(
+                module__input_size=X.shape[1], module__output_size=output_size
+            )
 
 
 # Step 1: Define the PyTorch Module for the MLP
 class MLPModule(nn.Module):
-    def __init__(self, input_size=10, hidden_layer_sizes=(50,), output_size=1):
-        super().__init__()
-        self.hidden_layers = nn.ModuleList()
-        self.output_layer = None
-        self.input_size = input_size
-        if input_size is not None and output_size is not None:
-            self.build_module(input_size, output_size, hidden_layer_sizes)
-
-    def build_module(self, input_size, output_size, hidden_layer_sizes):
-        hs = [input_size] + list(hidden_layer_sizes)
-        for i in range(len(hs) - 1):
-            self.hidden_layers.append(nn.Linear(hs[i], hs[i + 1]))
-        self.output_layer = nn.Linear(hidden_layer_sizes[-1], output_size)
+    def __init__(
+        self,
+        input_size: int = None,
+        output_size: int = None,
+        hidden_size: int = 100,
+    ):
+        super(MLPModule, self).__init__()
+        self.model = nn.Sequential(
+            nn.Linear(in_features=input_size, out_features=hidden_size),
+            nn.ReLU(),
+            nn.Linear(in_features=hidden_size, out_features=output_size),
+        )
 
     def forward(self, X: torch.Tensor):
-        X = X.to(torch.float32)
-        for layer in self.hidden_layers:
-            X = torch.relu(layer(X))
-        if self.output_layer is not None:
-            X = self.output_layer(X)
-        return X
+        return self.model(X)
 
 
 # Step 2: Create the Skorch wrapper for the NeuralNetRegressor
 class NeuralNetTorch(NeuralNetRegressor):
     def __init__(
         self,
-        module=MLPModule,
+        module: nn.Module = MLPModule,
         criterion=torch.nn.MSELoss,
         optimizer=torch.optim.Adam,
-        lr=0.01,
-        batch_size=128,
-        max_epochs=10,
-        module__input_size=10,
-        module__output_size=1,
-        module__hidden_layer_sizes=(100,),
-        optimizer__weight_decay=0.0001,
-        iterator_train__shuffle=True,
-        callbacks=[InputShapeSetter()],
-        train_split=False,  # to run cross_validate without splitting the data
-        verbose=0,
+        lr: float = 0.01,
+        batch_size: int = 128,
+        max_epochs: int = 10,
+        module__input_size: int = 10,
+        module__output_size: int = 1,
+        module__hidden_size: int = 100,
+        optimizer__weight_decay: float = 0.0001,
+        iterator_train__shuffle: bool = True,
+        callbacks: List[Callback] = [InputShapeSetter()],
+        train_split: bool = False,  # to run cross_validate without splitting the data
+        verbose: int = 0,
         **kwargs,
     ):
         if "random_state" in kwargs:
-            setattr(self, "random_state", kwargs.pop("random_state"))
-            set_random_seed(self.random_state)
+            set_random_seed(kwargs.pop("random_state"))
         super(NeuralNetTorch, self).__init__(
             module=module,
             criterion=criterion,
@@ -99,7 +103,7 @@ class NeuralNetTorch(NeuralNetRegressor):
             max_epochs=max_epochs,
             module__input_size=module__input_size,
             module__output_size=module__output_size,
-            module__hidden_layer_sizes=module__hidden_layer_sizes,
+            module__hidden_size=module__hidden_size,
             optimizer__weight_decay=optimizer__weight_decay,
             iterator_train__shuffle=iterator_train__shuffle,
             callbacks=callbacks,
@@ -110,11 +114,13 @@ class NeuralNetTorch(NeuralNetRegressor):
 
     def set_params(self, **params):
         if "random_state" in params:
-            set_random_seed(self.random_state)
-            # self._initialize_module()
-            # self._initialize_criterion()
-            # self._initialize_optimizer()
-        super(NeuralNetTorch, self).set_params(**params)
+            set_random_seed(params.pop("random_state"))
+            self._initialize_module()
+            self._initialize_criterion()
+            self._initialize_optimizer()
+            return self
+        else:
+            return super(NeuralNetTorch, self).set_params(**params)
 
     def get_grid_params(self, search_type="random"):
         param_grid_random = {
@@ -142,48 +148,59 @@ class NeuralNetTorch(NeuralNetRegressor):
         return param_grid
 
     def _more_tags(self):
-        return {"multioutput": True, "stateless": True}
+        return {"multioutput": True, "stateless": True, "poor_score": True}
 
     def check_data(self, X: np.ndarray, y: np.ndarray = None):
+        if isinstance(y, np.ndarray):
+            if np.iscomplex(X).any():
+                raise ValueError("Complex data not supported")
+        else:
+            X = np.array(X)
+        X = X.astype(np.float32)
+        if issparse(X):
+            raise ValueError("Sparse data not supported")
+        if np.isnan(X).any() or np.isinf(X).any():
+            raise ValueError("NaNs and inf values are not supported.")
         if X.size == 0:
             raise ValueError(
-                f"0 feature(s) (shape={X.shape}) while a minimum of {self.module__input_size} is required."
+                f"0 feature(s) (shape={X.shape}) while a minimum "
+                f"of {self.module__input_size} is required."
             )
         if X.ndim == 1:
             raise ValueError("Reshape your data")
-        if np.iscomplex(X).any():
-            raise ValueError("Complex data not supported")
-        X = X.astype(np.float32)
-        if np.isnan(X).any() or np.isinf(X).any():
-            raise ValueError("NaNs and inf values are not supported.")
         if y is not None:
-            if np.iscomplex(y).any():
-                raise ValueError("Complex data not supported")
+            if isinstance(y, np.ndarray):
+                if np.iscomplex(y).any():
+                    raise ValueError("Complex data not supported")
+            else:
+                y = np.array(y)
             y = y.astype(np.float32)
             if np.isnan(y).any() or np.isinf(y).any():
                 raise ValueError("NaNs and inf values are not supported.")
+        return X, y
 
     def fit_loop(self, X, y=None, epochs=None, **fit_params):
-        self.check_data(X, y)
-        X = X.astype(np.float32)
-        y = y.astype(np.float32)
-        super(NeuralNetRegressor, self).fit_loop(X, y, epochs, **fit_params)
+        X, y = self.check_data(X, y)
+        if not hasattr(self, "n_features_in_"):
+            setattr(self, "n_features_in_", X.shape[1])
+        return super(NeuralNetRegressor, self).fit_loop(X, y, epochs, **fit_params)
+
+    def partial_fit(self, X, y=None, classes=None, **fit_params):
+        X, y = self.check_data(X, y)
+        return super(NeuralNetRegressor, self).partial_fit(X, y, classes, **fit_params)
 
     def fit(self, X, y, **fit_params):
-        self.check_data(X, y)
-        X = X.astype(np.float32)
-        y = y.astype(np.float32)
-        estimator = super(NeuralNetRegressor, self).fit(X, y, **fit_params)
-        if not hasattr(estimator, "n_features_in_"):
-            setattr(estimator, "n_features_in_", X.shape[1])
-        return estimator
+        X, y = self.check_data(X, y)
+        super(NeuralNetRegressor, self).fit(X, y, **fit_params)
+        return self
 
-    def predict(self, X):
-        self.check_data(X)
-        X = X.astype(np.float32)
-        return super(NeuralNetRegressor, self).predict(X)
-
+    @torch.inference_mode()
     def predict_proba(self, X):
-        self.check_data(X)
-        X = X.astype(np.float32)
-        return super(NeuralNetRegressor, self).predict_proba(X)
+        dtype = X.dtype if hasattr(X, "dtype") else None
+        X, _ = self.check_data(X)
+        y_pred = super(NeuralNetRegressor, self).predict_proba(X)
+        if self.module__output_size == 1 and y_pred.shape[-1] == 1:
+            y_pred = np.squeeze(y_pred, axis=-1)
+        if dtype is not None:
+            y_pred = y_pred.astype(dtype)
+        return y_pred

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -2,19 +2,25 @@
 # to make it compatible with scikit-learn. Works with cross_validate and GridSearchCV,
 # but doesn't pass tests, because we're subclassing
 
-import torch
 import numpy as np
 import skorch
-from torch import nn
-from skorch import NeuralNetRegressor
+import torch
 from scipy.stats import loguniform
-from skopt.space import Real, Integer
+from skopt.space import Integer, Real
+from skorch import NeuralNetRegressor
+from torch import nn
 
 
 class InputShapeSetter(skorch.callbacks.Callback):
     """Callback to set input and output layer sizes dynamically."""
 
-    def on_train_begin(self, net, X, y):
+    def on_train_begin(
+        self,
+        net,
+        X: torch.Tensor | np.ndarray = None,
+        y: torch.Tensor | np.ndarray = None,
+        **kwargs
+    ):
         output_size = 1 if y.ndim == 1 else y.shape[1]
         net.set_params(module__input_size=X.shape[1], module__output_size=output_size)
 
@@ -35,7 +41,7 @@ class MLPModule(nn.Module):
             self.hidden_layers.append(nn.Linear(hs[i], hs[i + 1]))
         self.output_layer = nn.Linear(hidden_layer_sizes[-1], output_size)
 
-    def forward(self, X):
+    def forward(self, X: torch.Tensor):
         for layer in self.hidden_layers:
             X = torch.relu(layer(X))
         if self.output_layer is not None:

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -163,8 +163,11 @@ class NeuralNetTorch(NeuralNetRegressor):
 
         return param_grid
 
+    def __sklearn_is_fitted__(self):
+        return hasattr(self, "n_features_in_")
+
     def _more_tags(self):
-        return {"multioutput": True, "stateless": True, "poor_score": True}
+        return {"multioutput": True, "poor_score": True}
 
     def check_data(self, X: np.ndarray, y: np.ndarray = None):
         if isinstance(y, np.ndarray):

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -1,7 +1,13 @@
-import pytest
 import numpy as np
+import pytest
+
+from autoemulate.emulators import (
+    GaussianProcess,
+    NeuralNetSk,
+    NeuralNetTorch,
+    RandomForest,
+)
 from autoemulate.experimental_design import ExperimentalDesign, LatinHypercube
-from autoemulate.emulators import GaussianProcess, RandomForest
 
 
 def simple_sim(params):
@@ -38,6 +44,24 @@ def rf_model(simulation_io):
     rf = RandomForest()
     rf.fit(sim_in, sim_out)
     return rf
+
+
+@pytest.fixture(scope="module")
+def nn_sk_model(simulation_io):
+    """Setup for tests (Arrange)"""
+    sim_in, sim_out = simulation_io
+    nn_sk = NeuralNetSk()
+    nn_sk.fit(sim_in, sim_out)
+    return nn_sk
+
+
+@pytest.fixture(scope="module")
+def nn_torch_model(simulation_io):
+    """Setup for tests (Arrange)"""
+    sim_in, sim_out = simulation_io
+    nn_torch = NeuralNetTorch()
+    nn_torch.fit(sim_in, sim_out)
+    return nn_torch
 
 
 # Test Gaussian Process
@@ -97,4 +121,52 @@ def test_rf_pred_len(rf_model, simulation_io):
 def test_rf_pred_type(rf_model, simulation_io):
     sim_in, sim_out = simulation_io
     predictions = rf_model.predict(sim_in)
+    assert isinstance(predictions, np.ndarray)
+
+
+# Test Neural Network sklearn
+def test_nn_sk_initialisation():
+    nn_sk = NeuralNetSk()
+    assert nn_sk is not None
+
+
+def test_nn_sk_pred_exists(nn_sk_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_sk_model.predict(sim_in)
+    assert predictions is not None
+
+
+def test_nn_sk_pred_len(nn_sk_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_sk_model.predict(sim_in)
+    assert len(predictions) == len(sim_out)
+
+
+def test_nn_sk_pred_type(nn_sk_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_sk_model.predict(sim_in)
+    assert isinstance(predictions, np.ndarray)
+
+
+# Test PyTorch Neural Network (skorch)
+def test_nn_torch_initialisation():
+    nn_torch = NeuralNetTorch()
+    assert nn_torch is not None
+
+
+def test_nn_torch_pred_exists(nn_torch_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_torch_model.predict(sim_in)
+    assert predictions is not None
+
+
+def test_nn_torch_pred_len(nn_torch_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_torch_model.predict(sim_in)
+    assert len(predictions) == len(sim_out)
+
+
+def test_nn_torch_pred_type(nn_torch_model, simulation_io):
+    sim_in, sim_out = simulation_io
+    predictions = nn_torch_model.predict(sim_in)
     assert isinstance(predictions, np.ndarray)

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -176,3 +176,18 @@ def test_nn_torch_pred_type(nn_torch_model, simulation_io):
     sim_in = sim_in.astype(np.float32)
     predictions = nn_torch_model.predict(sim_in)
     assert isinstance(predictions, np.ndarray)
+
+
+def test_nn_torch_shape_setter():
+    input_size, output_size = 10, 2
+    X = np.random.rand(100, input_size)
+    y = np.random.rand(100, output_size)
+    nn_torch_model = NeuralNetTorch(
+        module__input_size=input_size, module__output_size=output_size
+    )
+    nn_torch_model.fit(X, y)
+    assert nn_torch_model.module__input_size == input_size
+    assert nn_torch_model.n_features_in_ == input_size
+    assert nn_torch_model.module_.model[0].in_features == input_size
+    assert nn_torch_model.module__output_size == output_size
+    assert nn_torch_model.module_.model[-1].out_features == output_size

--- a/tests/test_emulators.py
+++ b/tests/test_emulators.py
@@ -60,6 +60,8 @@ def nn_torch_model(simulation_io):
     """Setup for tests (Arrange)"""
     sim_in, sim_out = simulation_io
     nn_torch = NeuralNetTorch()
+    sim_in = sim_in.astype(np.float32)
+    sim_out = np.array(sim_out, dtype=np.float32)
     nn_torch.fit(sim_in, sim_out)
     return nn_torch
 
@@ -156,17 +158,21 @@ def test_nn_torch_initialisation():
 
 def test_nn_torch_pred_exists(nn_torch_model, simulation_io):
     sim_in, sim_out = simulation_io
+    sim_in = sim_in.astype(np.float32)
     predictions = nn_torch_model.predict(sim_in)
     assert predictions is not None
 
 
 def test_nn_torch_pred_len(nn_torch_model, simulation_io):
     sim_in, sim_out = simulation_io
+    sim_in = sim_in.astype(np.float32)
+    sim_out = np.array(sim_out, dtype=np.float32)
     predictions = nn_torch_model.predict(sim_in)
     assert len(predictions) == len(sim_out)
 
 
 def test_nn_torch_pred_type(nn_torch_model, simulation_io):
     sim_in, sim_out = simulation_io
+    sim_in = sim_in.astype(np.float32)
     predictions = nn_torch_model.predict(sim_in)
     assert isinstance(predictions, np.ndarray)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -23,15 +23,15 @@ from autoemulate.emulators import (
 
 @parametrize_with_checks(
     [
-        # SupportVectorMachines(),
-        # RandomForest(random_state=42),
-        # GaussianProcessSk(random_state=1337),
-        # NeuralNetSk(random_state=13),
-        # GradientBoosting(random_state=42),
-        # SecondOrderPolynomial(),
-        # XGBoost(),
-        # RBF(),
-        NeuralNetTorch(random_state=42),  # fails because it subclasses
+        SupportVectorMachines(),
+        RandomForest(random_state=42),
+        GaussianProcessSk(random_state=1337),
+        NeuralNetSk(random_state=13),
+        GradientBoosting(random_state=42),
+        SecondOrderPolynomial(),
+        XGBoost(),
+        RBF(),
+        NeuralNetTorch(random_state=42),
         # GaussianProcess()
     ]
 )

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -3,33 +3,35 @@
 # see https://scikit-learn.org/stable/developers/develop.html
 # and https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/estimator_checks.py
 
-from sklearn.utils.estimator_checks import parametrize_with_checks, _yield_all_checks
+from functools import partial
+
+from sklearn.utils.estimator_checks import _yield_all_checks, parametrize_with_checks
+
 from autoemulate.emulators import (
-    RandomForest,
-    GaussianProcessSk,
-    NeuralNetSk,
+    RBF,
     GaussianProcess,
-    NeuralNetTorch,
-    SecondOrderPolynomial,
+    GaussianProcessSk,
     GradientBoosting,
+    NeuralNetSk,
+    NeuralNetTorch,
+    RandomForest,
+    SecondOrderPolynomial,
     SupportVectorMachines,
     XGBoost,
-    RBF,
 )
-from functools import partial
 
 
 @parametrize_with_checks(
     [
-        SupportVectorMachines(),
-        RandomForest(random_state=42),
-        GaussianProcessSk(random_state=1337),
-        NeuralNetSk(random_state=13),
-        GradientBoosting(random_state=42),
-        SecondOrderPolynomial(),
-        XGBoost(),
-        RBF(),
-        # NeuralNetTorch(random_state=42), # fails because it subclasses
+        # SupportVectorMachines(),
+        # RandomForest(random_state=42),
+        # GaussianProcessSk(random_state=1337),
+        # NeuralNetSk(random_state=13),
+        # GradientBoosting(random_state=42),
+        # SecondOrderPolynomial(),
+        # XGBoost(),
+        # RBF(),
+        NeuralNetTorch(random_state=42),  # fails because it subclasses
         # GaussianProcess()
     ]
 )


### PR DESCRIPTION
- Implement skorch interface `NeuralNetTorch` and passed 37/41 tests in `test_estimators.py`
  - The 4 remaining failed tests has to do with skorch default implementation and scikit-learn `estimator_checks.py`:
    - scikit-learn `estimator_checks.py` initialize the `NeuralNetTorch` with default parameters, including the input and output size of the data. However, the actual input and output size are changed throughout the unit test, hence we have to dynamically re-initialize the PyTorch model (via `InputShapeSetter`), which is not allowed in scikit-learn estimator.
    - skorch `NeuralNetRegressor` implements the functions`["decision_function", "predict_proba", "predict_log_proba"]` which should not be supported for scikit-learn regressor.
    - skorch `NeuralNetRegressor` creates the attributes `self.history_`, `self.initilized_`, `self.virtual_params_` on initialization which is not allowed in scikit-learn estimator.
    - skorch `NeuralNetRegressor` expects to `callbacks` to be a list of callables whereas scikit-learn do not accept list of callables as parameter.
- update `.gitgnore` to ignore files from VSCode, PyCharm and macOS 