### PR TITLE
Rename `grid_search` and `param_grid`

### DIFF
--- a/autoemulate/compare.py
+++ b/autoemulate/compare.py
@@ -32,7 +32,7 @@ class AutoEmulate:
         self,
         X,
         y,
-        use_param_search=False,
+        param_search=False,
         param_search_type="random",
         param_search_iters=20,
         scale=True,
@@ -53,13 +53,13 @@ class AutoEmulate:
             Simulation input.
         y : array-like, shape (n_samples, n_outputs)
             Simulation output.
-        use_param_search : bool
+        param_search : bool
             Whether to perform hyperparameter search over predifined parameter grids.
         param_search_type : str
             Type of hyperparameter search to perform. Can be "grid", "random", or "bayes".
         param_search_iters : int
             Number of parameter settings that are sampled. Only used if
-            use_param_search=True and param_search_type="random".
+            param_search=True and param_search_type="random".
         scale : bool, default=True
             Whether to scale the data before fitting the models using a scaler.
         scaler : sklearn.preprocessing.StandardScaler
@@ -99,7 +99,7 @@ class AutoEmulate:
         )
         self.metrics = self._get_metrics(METRIC_REGISTRY)
         self.cv = self._get_cv(CV_REGISTRY, fold_strategy, folds)
-        self.use_param_search = use_param_search
+        self.param_search = param_search
         self.search_type = param_search_type
         self.param_search_iters = param_search_iters
         self.scale = scale
@@ -185,7 +185,7 @@ class AutoEmulate:
 
         for i in range(len(self.models)):
             # hyperparameter search
-            if self.use_param_search:
+            if self.param_search:
                 self.models[i] = optimize_params(
                     X=self.X,
                     y=self.y,

--- a/autoemulate/compare.py
+++ b/autoemulate/compare.py
@@ -32,9 +32,9 @@ class AutoEmulate:
         self,
         X,
         y,
-        use_grid_search=False,
-        grid_search_type="random",
-        grid_search_iters=20,
+        use_param_search=False,
+        param_search_type="random",
+        param_search_iters=20,
         scale=True,
         scaler=StandardScaler(),
         reduce_dim=False,
@@ -53,13 +53,13 @@ class AutoEmulate:
             Simulation input.
         y : array-like, shape (n_samples, n_outputs)
             Simulation output.
-        use_grid_search : bool
+        use_param_search : bool
             Whether to perform hyperparameter search over predifined parameter grids.
-        grid_search_type : str
+        param_search_type : str
             Type of hyperparameter search to perform. Can be "grid", "random", or "bayes".
-        grid_search_iters : int
+        param_search_iters : int
             Number of parameter settings that are sampled. Only used if
-            use_grid_search=True and grid_search_type="random".
+            use_param_search=True and param_search_type="random".
         scale : bool, default=True
             Whether to scale the data before fitting the models using a scaler.
         scaler : sklearn.preprocessing.StandardScaler
@@ -99,9 +99,9 @@ class AutoEmulate:
         )
         self.metrics = self._get_metrics(METRIC_REGISTRY)
         self.cv = self._get_cv(CV_REGISTRY, fold_strategy, folds)
-        self.use_grid_search = use_grid_search
-        self.search_type = grid_search_type
-        self.grid_search_iters = grid_search_iters
+        self.use_param_search = use_param_search
+        self.search_type = param_search_type
+        self.param_search_iters = param_search_iters
         self.scale = scale
         self.scaler = scaler
         self.n_jobs = n_jobs
@@ -185,14 +185,14 @@ class AutoEmulate:
 
         for i in range(len(self.models)):
             # hyperparameter search
-            if self.use_grid_search:
+            if self.use_param_search:
                 self.models[i] = optimize_params(
                     X=self.X,
                     y=self.y,
                     cv=self.cv,
                     model=self.models[i],
                     search_type=self.search_type,
-                    niter=self.grid_search_iters,
+                    niter=self.param_search_iters,
                     param_space=None,
                     n_jobs=self.n_jobs,
                     logger=self.logger,

--- a/autoemulate/compare.py
+++ b/autoemulate/compare.py
@@ -193,7 +193,7 @@ class AutoEmulate:
                     model=self.models[i],
                     search_type=self.search_type,
                     niter=self.grid_search_iters,
-                    param_grid=None,
+                    param_space=None,
                     n_jobs=self.n_jobs,
                     logger=self.logger,
                 )

--- a/autoemulate/emulators/gaussian_process.py
+++ b/autoemulate/emulators/gaussian_process.py
@@ -68,19 +68,19 @@ class GaussianProcess(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "nugget": ["fit", "adaptive", "pivot"],
         }
-        param_grid_bayes = {
+        param_space_bayes = {
             "nugget": Categorical(["fit", "adaptive", "pivot"]),
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": False}

--- a/autoemulate/emulators/gaussian_process_sk.py
+++ b/autoemulate/emulators/gaussian_process_sk.py
@@ -95,7 +95,7 @@ class GaussianProcessSk(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "kernel": [
                 RBF(),
                 Matern(),
@@ -106,7 +106,7 @@ class GaussianProcessSk(BaseEstimator, RegressorMixin):
             "alpha": loguniform(1e-10, 1e-2),
             "normalize_y": [True],
         }
-        param_grid_bayes = {
+        param_space_bayes = {
             # "kernel": Categorical([RBF(), Matern()]), # unhashable type
             "optimizer": Categorical(["fmin_l_bfgs_b"]),
             "alpha": Real(1e-10, 1e-2, prior="log-uniform"),
@@ -114,11 +114,11 @@ class GaussianProcessSk(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/emulators/gradient_boosting.py
+++ b/autoemulate/emulators/gradient_boosting.py
@@ -101,7 +101,7 @@ class GradientBoosting(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "learning_rate": loguniform(0.01, 0.2),
             "n_estimators": randint(100, 500),
             "max_depth": randint(3, 8),
@@ -112,7 +112,7 @@ class GradientBoosting(BaseEstimator, RegressorMixin):
             "ccp_alpha": loguniform(0.01, 0.1),
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             "learning_rate": Real(0.01, 0.2, prior="log-uniform"),
             "n_estimators": Integer(100, 500),
             "max_depth": Integer(3, 8),
@@ -124,11 +124,11 @@ class GradientBoosting(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": False}

--- a/autoemulate/emulators/neural_net_sk.py
+++ b/autoemulate/emulators/neural_net_sk.py
@@ -98,7 +98,7 @@ class NeuralNetSk(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "hidden_layer_sizes": [
                 (50,),
                 (100,),
@@ -112,7 +112,7 @@ class NeuralNetSk(BaseEstimator, RegressorMixin):
             "learning_rate_init": loguniform(1e-4, 1e-2),
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             # doesn't work with bayes
             # "hidden_layer_sizes": Categorical([
             #     (50,),
@@ -128,11 +128,11 @@ class NeuralNetSk(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -141,7 +141,7 @@ class NeuralNetTorch(NeuralNetRegressor):
         return self
 
     def get_grid_params(self, search_type="random"):
-        param_grid_random = {
+        param_space_random = {
             "lr": loguniform(1e-4, 1e-2),
             "max_epochs": [10, 20, 30],
             "module__hidden_sizes": [
@@ -153,17 +153,17 @@ class NeuralNetTorch(NeuralNetRegressor):
             ],
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             "lr": Real(1e-4, 1e-2, prior="log-uniform"),
             "max_epochs": Integer(10, 30),
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def __sklearn_is_fitted__(self):
         return hasattr(self, "n_features_in_")

--- a/autoemulate/emulators/polynomials.py
+++ b/autoemulate/emulators/polynomials.py
@@ -82,11 +82,11 @@ class SecondOrderPolynomial(BaseEstimator, RegressorMixin):
             The parameter grid for the model.
         """
         if search_type == "random":
-            param_grid = {}
+            param_space = {}
         elif search_type == "bayes":
-            param_grid = [({"degree": Categorical([2])}, 1)]
+            param_space = [({"degree": Categorical([2])}, 1)]
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/emulators/random_forest.py
+++ b/autoemulate/emulators/random_forest.py
@@ -96,7 +96,7 @@ class RandomForest(BaseEstimator, RegressorMixin):
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
 
-        param_grid_random = {
+        param_space_random = {
             "n_estimators": randint(50, 500),
             "min_samples_split": randint(2, 20),
             "min_samples_leaf": randint(1, 10),
@@ -107,7 +107,7 @@ class RandomForest(BaseEstimator, RegressorMixin):
             "max_samples": [None, 0.5, 0.75],
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             "n_estimators": Integer(50, 500),
             "min_samples_split": Integer(2, 20),
             "min_samples_leaf": Integer(1, 10),
@@ -119,11 +119,11 @@ class RandomForest(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/emulators/rbf.py
+++ b/autoemulate/emulators/rbf.py
@@ -85,13 +85,13 @@ class RBF(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        # param_grid_random = {
+        # param_space_random = {
         #     #"smoothing": uniform(0.0, 1.0),
         #     "kernel": ["linear", "thin_plate_spline", "cubic", "quintic", "multiquadric", "inverse_multiquadric", "gaussian"],
         #     #"epsilon": uniform(0.0, 1.0),
         #     "degree": randint(0, 5),
         # }
-        param_grid_random = [
+        param_space_random = [
             {
                 "kernel": ["linear", "multiquadric"],
                 "degree": randint(0, 3),  # Degrees valid for these kernels
@@ -114,7 +114,7 @@ class RBF(BaseEstimator, RegressorMixin):
             },
         ]
 
-        param_grid_bayes = [
+        param_space_bayes = [
             {
                 "kernel": Categorical(["linear", "multiquadric"]),
                 "degree": Integer(0, 4),  # Degrees valid for these kernels
@@ -138,11 +138,11 @@ class RBF(BaseEstimator, RegressorMixin):
         ]
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/emulators/support_vector_machines.py
+++ b/autoemulate/emulators/support_vector_machines.py
@@ -125,7 +125,7 @@ class SupportVectorMachines(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid paramaters for the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "kernel": ["rbf", "linear", "poly", "sigmoid"],
             "degree": randint(2, 6),
             "gamma": ["scale", "auto"],
@@ -139,7 +139,7 @@ class SupportVectorMachines(BaseEstimator, RegressorMixin):
             "max_iter": [-1],
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             "kernel": Categorical(["rbf", "linear", "poly", "sigmoid"]),
             "degree": Integer(2, 5),
             "gamma": Categorical(["scale", "auto"]),
@@ -154,11 +154,11 @@ class SupportVectorMachines(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": False}

--- a/autoemulate/emulators/xgboost.py
+++ b/autoemulate/emulators/xgboost.py
@@ -132,7 +132,7 @@ class XGBoost(BaseEstimator, RegressorMixin):
 
     def get_grid_params(self, search_type="random"):
         """Returns the grid parameters of the emulator."""
-        param_grid_random = {
+        param_space_random = {
             "booster": ["gbtree", "dart"],
             "n_estimators": randint(100, 1000),
             "max_depth": randint(3, 10),
@@ -148,7 +148,7 @@ class XGBoost(BaseEstimator, RegressorMixin):
             "reg_lambda": loguniform(0.01, 1),
         }
 
-        param_grid_bayes = {
+        param_space_bayes = {
             "booster": Categorical(["gbtree", "dart"]),
             "n_estimators": Integer(100, 1000),
             "max_depth": Integer(3, 10),
@@ -165,11 +165,11 @@ class XGBoost(BaseEstimator, RegressorMixin):
         }
 
         if search_type == "random":
-            param_grid = param_grid_random
+            param_space = param_space_random
         elif search_type == "bayes":
-            param_grid = param_grid_bayes
+            param_space = param_space_bayes
 
-        return param_grid
+        return param_space
 
     def _more_tags(self):
         return {"multioutput": True}

--- a/autoemulate/utils.py
+++ b/autoemulate/utils.py
@@ -102,7 +102,7 @@ def get_model_params(model):
         return model.get_params()
 
 
-def get_model_param_grid(model, search_type="random"):
+def get_model_param_space(model, search_type="random"):
     """Get the parameter grid of the base model. This is used for hyperparameter search.
 
     This function handles standalone models, models wrapped in a MultiOutputRegressor,
@@ -138,7 +138,7 @@ def get_model_param_grid(model, search_type="random"):
         return model.get_grid_params(search_type)
 
 
-def adjust_param_grid(model, param_grid):
+def adjust_param_space(model, param_space):
     """Adjusts param grid to be compatible with the model.
     Adds `model__` if model is a pipeline and
     `estimator__` if model is a MultiOutputRegressor. Or `model__estimator__` if both,
@@ -148,14 +148,14 @@ def adjust_param_grid(model, param_grid):
     ----------
     model : model instance or Pipeline
         The pipeline, model or MultiOutputRegressor to which the param grid should be adjusted.
-    param_grid : dict
+    param_space : dict
         The param grid to be adjusted. This is a dictionary with the parameter names as keys
         which would work for GridSearchCv if the model wouldn't be wrapped in a pipeline or
         MultiOutputRegressor.
 
     Returns
     -------
-    param_grid : dict
+    param_space : dict
         Adjusted param grid.
     """
     if isinstance(model, Pipeline):
@@ -167,28 +167,28 @@ def adjust_param_grid(model, param_grid):
             prefix = "model__"
     elif isinstance(model, MultiOutputRegressor):
         prefix = "estimator__"
-    # if model isn't wrapped in anything return param_grid as is
+    # if model isn't wrapped in anything return param_space as is
     elif isinstance(model, RegressorMixin):
-        return param_grid
+        return param_space
 
-    return add_prefix_to_param_grid(param_grid, prefix)
+    return add_prefix_to_param_space(param_space, prefix)
 
 
-def add_prefix_to_param_grid(param_grid, prefix):
+def add_prefix_to_param_space(param_space, prefix):
     """Adds a prefix to all keys in a parameter grid.
 
-    Works for three types of param_grids:
-    * when param_grid is a dict (standard case)
-    * when param_grid is a list of dicts (when we only want
+    Works for three types of param_spaces:
+    * when param_space is a dict (standard case)
+    * when param_space is a list of dicts (when we only want
     to iterate over certain parameter combinations, like in RBF)
-    * when param_grid contains tuples of (dict, int) (when we want
+    * when param_space contains tuples of (dict, int) (when we want
     to iterate a certain number of times over a parameter subspace
     (only in BayesSearchCV). This can be used to prevent bayes search
     from iterating many times using the same parameters.
 
     Parameters
     ----------
-    param_grid : dict or list of dicts
+    param_space : dict or list of dicts
         The parameter grid to which the prefix will be added.
     prefix : str
         The prefix to be added to each parameter name in the grid.
@@ -198,21 +198,21 @@ def add_prefix_to_param_grid(param_grid, prefix):
     dict or list of dicts
         The parameter grid with the prefix added to each key.
     """
-    if isinstance(param_grid, list):
-        new_param_grid = []
-        for param in param_grid:
+    if isinstance(param_space, list):
+        new_param_space = []
+        for param in param_space:
             # Handle tuple (dict, int) used in BayesSearchCV
             if isinstance(param, tuple):
                 # Reconstruct the tuple with the modified dictionary
                 dict_with_prefix = add_prefix_to_single_grid(param[0], prefix)
-                new_param_grid.append((dict_with_prefix,) + param[1:])
+                new_param_space.append((dict_with_prefix,) + param[1:])
             elif isinstance(param, dict):
                 # Add prefix to the dictionary
-                new_param_grid.append(add_prefix_to_single_grid(param, prefix))
-        return new_param_grid
+                new_param_space.append(add_prefix_to_single_grid(param, prefix))
+        return new_param_space
     else:
-        # If param_grid is a single dictionary, add the prefix directly
-        return add_prefix_to_single_grid(param_grid, prefix)
+        # If param_space is a single dictionary, add the prefix directly
+        return add_prefix_to_single_grid(param_space, prefix)
 
 
 def add_prefix_to_single_grid(grid, prefix):

--- a/tests/test_hyperparam_searching.py
+++ b/tests/test_hyperparam_searching.py
@@ -5,9 +5,9 @@ from sklearn.datasets import make_regression
 from sklearn.pipeline import Pipeline
 
 from autoemulate.emulators import RandomForest
-from autoemulate.hyperparam_searching import check_param_grid
+from autoemulate.hyperparam_searching import check_param_space
 from autoemulate.hyperparam_searching import optimize_params
-from autoemulate.hyperparam_searching import process_param_grid
+from autoemulate.hyperparam_searching import process_param_space
 from autoemulate.utils import get_model_name
 
 
@@ -25,7 +25,7 @@ def model():
 
 # param grid for random forest
 @pytest.fixture
-def param_grid():
+def param_space():
     return {
         "n_estimators": [10, 20],
         "max_depth": [None, 3],
@@ -49,39 +49,39 @@ def test_optimize_params(Xy, model):
     assert best_estimator.named_steps["model"].is_fitted_ == True
 
 
-def test_process_param_grid_none(model, param_grid):
+def test_process_param_space_none(model, param_space):
     search_type = "random"
-    param_grid = process_param_grid(model, search_type, param_grid=None)
-    # check that param_grid has been populated
-    assert type(param_grid) == dict
+    param_space = process_param_space(model, search_type, param_space=None)
+    # check that param_space has been populated
+    assert type(param_space) == dict
 
 
-def test_process_param_grid(model, param_grid):
+def test_process_param_space(model, param_space):
     search_type = "random"
-    param_grid = process_param_grid(model, search_type, param_grid)
-    # check that param_grid has been populated
-    assert type(param_grid) == dict
+    param_space = process_param_space(model, search_type, param_space)
+    # check that param_space has been populated
+    assert type(param_space) == dict
 
 
-def test_process_param_grid_invalid(model, param_grid):
+def test_process_param_space_invalid(model, param_space):
     search_type = "random"
-    param_grid = {"invalid_param": [1, 2]}
+    param_space = {"invalid_param": [1, 2]}
     with pytest.raises(ValueError):
-        param_grid = process_param_grid(model, search_type, param_grid)
+        param_space = process_param_space(model, search_type, param_space)
 
 
-def test_check_param_grid(param_grid, model):
-    # param_grid should be a dictionary
+def test_check_param_space(param_space, model):
+    # param_space should be a dictionary
     with pytest.raises(TypeError):
-        check_param_grid(model, [])
-    # keys in param_grid should be strings
+        check_param_space(model, [])
+    # keys in param_space should be strings
     with pytest.raises(TypeError):
-        check_param_grid({1: []}, model)
-    # values in param_grid should be lists
+        check_param_space({1: []}, model)
+    # values in param_space should be lists
     with pytest.raises(TypeError):
-        check_param_grid({"n_estimators": 10}, model)
+        check_param_space({"n_estimators": 10}, model)
     #     # model__ prefixed keys should be actual parameters in the model
     with pytest.raises(ValueError):
-        check_param_grid({"model__invalid_param": [1, 2]}, model)
-    # check param_grid returned if valid
-    assert check_param_grid(param_grid, model) == param_grid
+        check_param_space({"model__invalid_param": [1, 2]}, model)
+    # check param_space returned if valid
+    assert check_param_space(param_space, model) == param_space

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,13 +7,13 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
 from autoemulate.emulators import GradientBoosting
-from autoemulate.utils import add_prefix_to_param_grid
+from autoemulate.utils import add_prefix_to_param_space
 from autoemulate.utils import add_prefix_to_single_grid
-from autoemulate.utils import adjust_param_grid
+from autoemulate.utils import adjust_param_space
 from autoemulate.utils import denormalise_y
 from autoemulate.utils import get_mean_scores
 from autoemulate.utils import get_model_name
-from autoemulate.utils import get_model_param_grid
+from autoemulate.utils import get_model_param_space
 from autoemulate.utils import normalise_y
 
 
@@ -60,7 +60,7 @@ def model():
 
 # gets all the parameters of the model with the sklearn get_params() method
 @pytest.fixture
-def param_grid(model):
+def param_space(model):
     return model.get_params()
 
 
@@ -91,7 +91,7 @@ def model():
 
 # gets all the parameters of the model with the sklearn get_params() method
 @pytest.fixture
-def param_grid(model):
+def param_space(model):
     return model.get_params()
 
 
@@ -115,64 +115,64 @@ def model_multiout_pipe(model):
     return Pipeline([("model", MultiOutputRegressor(model))])
 
 
-# test get_model_param_grid ----------------------------------------------------
-def test_param_basic_random(model, param_grid):
-    model_grid = get_model_param_grid(model, search_type="random")
-    # check that all keys in model_grid are in param_grid
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+# test get_model_param_space ----------------------------------------------------
+def test_param_basic_random(model, param_space):
+    model_grid = get_model_param_space(model, search_type="random")
+    # check that all keys in model_grid are in param_space
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-def test_param_basic_bayes(model, param_grid):
-    model_grid = get_model_param_grid(model, search_type="bayes")
-    # check that all keys in model_grid are in param_grid
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+def test_param_basic_bayes(model, param_space):
+    model_grid = get_model_param_space(model, search_type="bayes")
+    # check that all keys in model_grid are in param_space
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-def test_param_pipe(model_in_pipe, param_grid):
-    model_grid = get_model_param_grid(model_in_pipe)
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+def test_param_pipe(model_in_pipe, param_space):
+    model_grid = get_model_param_space(model_in_pipe)
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-def test_param_pipe_scaler(model_in_pipe_w_scaler, param_grid):
-    model_grid = get_model_param_grid(model_in_pipe_w_scaler)
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+def test_param_pipe_scaler(model_in_pipe_w_scaler, param_space):
+    model_grid = get_model_param_space(model_in_pipe_w_scaler)
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-def test_param_multiout(model_multiout, param_grid):
-    model_grid = get_model_param_grid(model_multiout)
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+def test_param_multiout(model_multiout, param_space):
+    model_grid = get_model_param_space(model_multiout)
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-def test_param_multiout_pipe(model_multiout_pipe, param_grid):
-    model_grid = get_model_param_grid(model_multiout_pipe)
-    assert all(key in param_grid.keys() for key in model_grid.keys())
+def test_param_multiout_pipe(model_multiout_pipe, param_space):
+    model_grid = get_model_param_space(model_multiout_pipe)
+    assert all(key in param_space.keys() for key in model_grid.keys())
 
 
-# test adjust_param_grid -------------------------------------------------------
-def test_adj_param_basic(model, param_grid):
-    adjusted_param_grid = adjust_param_grid(model, param_grid)
-    assert all(key in param_grid.keys() for key in adjusted_param_grid.keys())
+# test adjust_param_space -------------------------------------------------------
+def test_adj_param_basic(model, param_space):
+    adjusted_param_space = adjust_param_space(model, param_space)
+    assert all(key in param_space.keys() for key in adjusted_param_space.keys())
 
 
-def test_adj_param_pipe(model_in_pipe, param_grid):
-    adjusted_param_grid = adjust_param_grid(model_in_pipe, param_grid)
-    assert all(key.startswith("model__") for key in adjusted_param_grid.keys())
+def test_adj_param_pipe(model_in_pipe, param_space):
+    adjusted_param_space = adjust_param_space(model_in_pipe, param_space)
+    assert all(key.startswith("model__") for key in adjusted_param_space.keys())
 
 
-def test_adj_param_pipe_scaler(model_in_pipe_w_scaler, param_grid):
-    adjusted_param_grid = adjust_param_grid(model_in_pipe_w_scaler, param_grid)
-    assert all(key.startswith("model__") for key in adjusted_param_grid.keys())
+def test_adj_param_pipe_scaler(model_in_pipe_w_scaler, param_space):
+    adjusted_param_space = adjust_param_space(model_in_pipe_w_scaler, param_space)
+    assert all(key.startswith("model__") for key in adjusted_param_space.keys())
 
 
-def test_adj_param_multiout(model_multiout, param_grid):
-    adjusted_param_grid = adjust_param_grid(model_multiout, param_grid)
-    assert all(key.startswith("estimator__") for key in adjusted_param_grid.keys())
+def test_adj_param_multiout(model_multiout, param_space):
+    adjusted_param_space = adjust_param_space(model_multiout, param_space)
+    assert all(key.startswith("estimator__") for key in adjusted_param_space.keys())
 
 
-def test_adj_param_multiout_pipe(model_multiout_pipe, param_grid):
-    adjusted_param_grid = adjust_param_grid(model_multiout_pipe, param_grid)
+def test_adj_param_multiout_pipe(model_multiout_pipe, param_space):
+    adjusted_param_space = adjust_param_space(model_multiout_pipe, param_space)
     assert all(
-        key.startswith("model__estimator__") for key in adjusted_param_grid.keys()
+        key.startswith("model__estimator__") for key in adjusted_param_space.keys()
     )
 
 
@@ -212,7 +212,7 @@ def test_denormalise_2d():
     np.testing.assert_array_almost_equal(y, y_denorm)
 
 
-# test add_prefix_to_param_grid ------------------------------------------------
+# test add_prefix_to_param_space ------------------------------------------------
 
 
 @pytest.fixture
@@ -241,9 +241,9 @@ def prefix():
     return "prefix_"
 
 
-def test_add_prefix_to_param_grid_dict(grid, prefix):
+def test_add_prefix_to_param_space_dict(grid, prefix):
     """
-    Test whether add_prefix_to_param_grid correctly adds a prefix to each key
+    Test whether add_prefix_to_param_space correctly adds a prefix to each key
     in a parameter grid dictionary.
     """
     expected_result = {
@@ -252,13 +252,13 @@ def test_add_prefix_to_param_grid_dict(grid, prefix):
         "prefix_param3": [7, 8, 9],
     }
     assert (
-        add_prefix_to_param_grid(grid, prefix) == expected_result
+        add_prefix_to_param_space(grid, prefix) == expected_result
     ), "Prefix not correctly added to param grid dict"
 
 
-def test_add_prefix_to_param_grid_list(grid_list, prefix):
+def test_add_prefix_to_param_space_list(grid_list, prefix):
     """
-    Test whether add_prefix_to_param_grid correctly adds a prefix to each key
+    Test whether add_prefix_to_param_space correctly adds a prefix to each key
     in a list of parameter grid dictionaries.
     """
     expected_result = [
@@ -266,15 +266,15 @@ def test_add_prefix_to_param_grid_list(grid_list, prefix):
         {"prefix_param3": [7, 8, 9], "prefix_param4": [10, 11, 12]},
     ]
     assert (
-        add_prefix_to_param_grid(grid_list, prefix) == expected_result
+        add_prefix_to_param_space(grid_list, prefix) == expected_result
     ), "Prefix not correctly added to param grid list"
 
     # test add_prefix_to_single_grid ------------------------------------------------
 
 
-def test_add_prefix_to_param_grid_list_of_tuples(grid_list_of_tuples, prefix):
+def test_add_prefix_to_param_space_list_of_tuples(grid_list_of_tuples, prefix):
     """
-    Test whether add_prefix_to_param_grid correctly adds a prefix to each key
+    Test whether add_prefix_to_param_space correctly adds a prefix to each key
     in a list of parameter grid dictionaries.
     """
     expected_result = [
@@ -282,7 +282,7 @@ def test_add_prefix_to_param_grid_list_of_tuples(grid_list_of_tuples, prefix):
         ({"prefix_param2": [4, 5, 6]}, 1),
     ]
     assert (
-        add_prefix_to_param_grid(grid_list_of_tuples, prefix) == expected_result
+        add_prefix_to_param_space(grid_list_of_tuples, prefix) == expected_result
     ), "Prefix not correctly added to param grid list of tuples"
 
 


### PR DESCRIPTION
To `param_search` and `param_space`. This is to be correct when talking about random and bayes hyperparameter search.

Resolves #105 