### PR TITLE
`MLPModule` search space for `cardiac` datasets

### DIFF
--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -92,8 +92,7 @@ class NeuralNetTorch(NeuralNetRegressor):
             else:
                 setattr(self, "random_state", random_state)
             set_random_seed(self.random_state)
-            self._initialize_module()
-            self._initialize_optimizer()
+            self.initialize()
         return super().set_params(**params)
 
     def initialize_module(self, reason=None):
@@ -117,10 +116,9 @@ class NeuralNetTorch(NeuralNetRegressor):
             "_xfail_checks": {
                 "check_no_attributes_set_in_init": "skorch initialize attributes in __init__.",
                 "check_regressors_no_decision_function": "skorch NeuralNetRegressor class implements the predict_proba.",
-                # "check_parameters_default_constructible": "skorch NeuralNet class callbacks parameter expects a list of callables.",
-                # "check_dont_overwrite_parameters": "the change of public attribute module__input_size is needed to support dynamic input size.",
-                # "check_estimators_overwrite_params": "module parameters changes upon fitting the estimator hence produce non-identical result.",
-                # "check_estimators_unfitted": "NeuralNetTorch does not support prediction without initializing the module.",
+                "check_parameters_default_constructible": "skorch NeuralNet class callbacks parameter expects a list of callables.",
+                "check_methods_subset_invariance": "the assert_allclose check is done in float64 while Torch models operate in float32. The max absolute difference is 1.1920929e-07.",
+                "check_dont_overwrite_parameters": "the change of public attribute module__input_size is needed to support dynamic input size.",
             },
         }
 

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -56,7 +56,7 @@ class NeuralNetTorch(NeuralNetRegressor):
         max_epochs: int = 1,
         module__input_size: int = 2,
         module__output_size: int = 1,
-        optimizer__weight_decay: float = 0.0001,
+        optimizer__weight_decay: float = 0.0,
         iterator_train__shuffle: bool = True,
         callbacks: List[Callback] = [InputShapeSetter()],
         train_split: bool = False,  # to run cross_validate without splitting the data

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from scipy.sparse import issparse
 from sklearn.exceptions import DataConversionWarning
+from sklearn.exceptions import NotFittedError
 from skorch import NeuralNetRegressor
 from skorch.callbacks import Callback
 
@@ -49,8 +50,8 @@ class NeuralNetTorch(NeuralNetRegressor):
         self,
         module: str = "mlp",
         criterion=torch.nn.MSELoss,
-        optimizer=torch.optim.Adam,
-        lr: float = 0.01,
+        optimizer=torch.optim.AdamW,
+        lr: float = 1e-3,
         batch_size: int = 128,
         max_epochs: int = 1,
         module__input_size: int = 2,
@@ -65,17 +66,8 @@ class NeuralNetTorch(NeuralNetRegressor):
         if "random_state" in kwargs:
             setattr(self, "random_state", kwargs.pop("random_state"))
             set_random_seed(self.random_state)
-        # get all arguments for module initialization
-        module_args = {
-            "input_size": module__input_size,
-            "output_size": module__output_size,
-        }
-        for k, v in kwargs.items():
-            if k.startswith("module__"):
-                module_args[k.replace("module__", "")] = v
-
         super().__init__(
-            module=get_module(module, module_args),
+            module=get_module(module),
             criterion=criterion,
             optimizer=optimizer,
             lr=lr,
@@ -90,8 +82,7 @@ class NeuralNetTorch(NeuralNetRegressor):
             verbose=verbose,
             **kwargs,
         )
-        self._initialize_module()
-        self._initialize_optimizer()
+        self.initialize()
 
     def set_params(self, **params):
         if "random_state" in params:
@@ -126,10 +117,10 @@ class NeuralNetTorch(NeuralNetRegressor):
             "_xfail_checks": {
                 "check_no_attributes_set_in_init": "skorch initialize attributes in __init__.",
                 "check_regressors_no_decision_function": "skorch NeuralNetRegressor class implements the predict_proba.",
-                "check_parameters_default_constructible": "skorch NeuralNet class callbacks parameter expects a list of callables.",
-                "check_dont_overwrite_parameters": "the change of public attribute module__input_size is needed to support dynamic input size.",
-                "check_estimators_overwrite_params": "module parameters changes upon fitting the estimator hence produce non-identical result.",
-                "check_estimators_unfitted": "NeuralNetTorch does not support prediction without initializing the module.",
+                # "check_parameters_default_constructible": "skorch NeuralNet class callbacks parameter expects a list of callables.",
+                # "check_dont_overwrite_parameters": "the change of public attribute module__input_size is needed to support dynamic input size.",
+                # "check_estimators_overwrite_params": "module parameters changes upon fitting the estimator hence produce non-identical result.",
+                # "check_estimators_unfitted": "NeuralNetTorch does not support prediction without initializing the module.",
             },
         }
 
@@ -183,6 +174,8 @@ class NeuralNetTorch(NeuralNetRegressor):
 
     @torch.inference_mode()
     def predict_proba(self, X):
+        if not hasattr(self, "n_features_in_"):
+            raise NotFittedError
         dtype = X.dtype if hasattr(X, "dtype") else None
         X, _ = self.check_data(X)
         y_pred = super().predict_proba(X)

--- a/autoemulate/emulators/neural_networks/get_module.py
+++ b/autoemulate/emulators/neural_networks/get_module.py
@@ -2,16 +2,16 @@ from autoemulate.emulators.neural_networks import TorchModule
 from autoemulate.emulators.neural_networks.mlp import MLPModule
 
 
-def get_module(module: str | TorchModule, module_args) -> TorchModule:
+def get_module(module: str | TorchModule) -> TorchModule:
     """
-    Return the module instance for NeuralNetRegressor. If `module` is a string,
-    then initialize a TorchModule with the same registered name. If `module` is
+    Return the module class for NeuralNetRegressor. If `module` is
     already a TorchModule, then return it as is.
     """
-    if not isinstance(module, TorchModule):
-        match module:
-            case "mlp":
-                module = MLPModule(**module_args)
-            case _:
-                raise NotImplementedError(f"Module {module} not implemented.")
+    if not isinstance(module, str):
+        return module
+    match module:
+        case "mlp":
+            module = MLPModule
+        case _:
+            raise NotImplementedError(f"Module {module} not implemented.")
     return module

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -49,6 +49,7 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
+            "optimizer": [torch.optim.AdamW, torch.optim.SGD],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -18,7 +18,8 @@ class MLPModule(TorchModule):
         input_size: int = None,
         output_size: int = None,
         random_state: int = None,
-        hidden_sizes: Tuple[int] = (100,),
+        hidden_layers: int = 1,
+        hidden_size: int = 100,
         hidden_activation: Tuple[callable] = nn.ReLU,
     ):
         super(MLPModule, self).__init__(
@@ -28,7 +29,8 @@ class MLPModule(TorchModule):
             random_state=random_state,
         )
         modules = []
-        for hidden_size in hidden_sizes:
+        assert hidden_layers >= 1
+        for _ in range(hidden_layers):
             modules.append(nn.Linear(in_features=input_size, out_features=hidden_size))
             modules.append(hidden_activation())
             input_size = hidden_size
@@ -37,18 +39,23 @@ class MLPModule(TorchModule):
 
     def get_grid_params(self, search_type: str = "random"):
         param_space = {
-            "lr": loguniform(1e-06, 0.01),
             "max_epochs": np.arange(10, 110, 10).tolist(),
             "batch_size": np.arange(2, 128, 2).tolist(),
-            "module__hidden_sizes": [(50,), (100,), (100, 100), (100, 200), (200, 200)],
-            "module__hidden_activation": [nn.ReLU, nn.Tanh, nn.Sigmoid, nn.GELU],
-            "optimizer__weight_decay": (1 / 10 ** np.arange(1, 10)).tolist(),
+            "module__hidden_layers": np.arange(1, 4).tolist(),
+            "module__hidden_size": np.arange(50, 250, 50).tolist(),
+            "module__hidden_activation": [
+                nn.ReLU,
+                nn.Tanh,
+                nn.Sigmoid,
+                nn.GELU,
+            ],
+            "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
-                pass
+                param_space |= {"lr": loguniform(1e-06, 1e-2)}
             case "bayes":
-                pass
+                param_space |= {"lr": Real(1e-06, 1e-2, prior="log-uniform")}
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")
 

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -19,6 +19,7 @@ class MLPModule(TorchModule):
         output_size: int = None,
         random_state: int = None,
         hidden_sizes: Tuple[int] = (100,),
+        hidden_activation: Tuple[callable] = nn.ReLU,
     ):
         super(MLPModule, self).__init__(
             module_name="mlp",
@@ -29,7 +30,7 @@ class MLPModule(TorchModule):
         modules = []
         for hidden_size in hidden_sizes:
             modules.append(nn.Linear(in_features=input_size, out_features=hidden_size))
-            modules.append(nn.ReLU())
+            modules.append(hidden_activation())
             input_size = hidden_size
         modules.append(nn.Linear(in_features=input_size, out_features=output_size))
         self.model = nn.Sequential(*modules)
@@ -38,18 +39,10 @@ class MLPModule(TorchModule):
         param_space = {
             "lr": loguniform(1e-06, 0.01),
             "max_epochs": np.arange(10, 110, 10).tolist(),
-            "module__hidden_sizes": [
-                (32,),
-                (64,),
-                (128,),
-                (128, 128),
-                (128, 256),
-                (256, 256),
-                (512, 512),
-                (128, 128, 128),
-            ],
             "batch_size": np.arange(2, 128, 2).tolist(),
-            "optimizer__weight_decay": loguniform(1e-8, 0.1),
+            "module__hidden_sizes": [(50,), (100,), (100, 100), (100, 200), (200, 200)],
+            "module__hidden_activation": [nn.ReLU, nn.Tanh, nn.Sigmoid, nn.GELU],
+            "optimizer__weight_decay": (1 / 10 ** np.arange(1, 10)).tolist(),
         }
         match search_type:
             case "random":

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import numpy as np
 import torch
 from scipy.stats import loguniform
 from skopt.space import Integer
@@ -34,24 +35,27 @@ class MLPModule(TorchModule):
         self.model = nn.Sequential(*modules)
 
     def get_grid_params(self, search_type: str = "random"):
+        param_space = {
+            "lr": loguniform(1e-06, 0.01),
+            "max_epochs": np.arange(10, 110, 10).tolist(),
+            "module__hidden_sizes": [
+                (32,),
+                (64,),
+                (128,),
+                (128, 128),
+                (128, 256),
+                (256, 256),
+                (512, 512),
+                (128, 128, 128),
+            ],
+            "batch_size": np.arange(2, 128, 2).tolist(),
+            "optimizer__weight_decay": loguniform(1e-8, 0.1),
+        }
         match search_type:
             case "random":
-                param_space = {
-                    "lr": loguniform(1e-4, 1e-2),
-                    "max_epochs": [10, 20, 30],
-                    "module__hidden_sizes": [
-                        (50,),
-                        (100,),
-                        (100, 50),
-                        (100, 100),
-                        (200, 100),
-                    ],
-                }
+                pass
             case "bayes":
-                param_space = {
-                    "lr": Real(1e-4, 1e-2, prior="log-uniform"),
-                    "max_epochs": Integer(10, 30),
-                }
+                pass
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")
 


### PR DESCRIPTION
- update `get_module` to return only the class, without initialization, so that subsequent calls to `set_params` can result `self.module`. 
  - this update fixed 2 test cases which we previously ignored
  - this also allows the `em.compare()` function to set the module hyperparameter properly
- use [`AdamW`](https://arxiv.org/abs/1711.05101) instead of `Adam` as default optimizer and set default learning rate to `1e-3` to align with PyTorch.
- updated `MLPModule` search space, add `batch_size`, `optimizer__weight_decay`, `module__hidden_activation`.

address Issue https://github.com/alan-turing-institute/autoemulate/issues/128

Example on `cardiac1` dataset
```
autoemulate - Performing grid search for NeuralNetTorch...
autoemulate - Best parameters for NeuralNetTorch: {'model__batch_size': 2, 'model__lr': 0.00031021307432157666, 'model__max_epochs': 70, 'model__module__hidden_activation': <class 'torch.nn.modules.activation.Tanh'>, 'model__module__hidden_sizes': (100, 100), 'model__optimizer__weight_decay': 0.04215478953678464}
autoemulate - Cross-validating NeuralNetTorch...
autoemulate - Parameters: {'module': <class 'autoemulate.emulators.neural_networks.mlp.MLPModule'>, 'criterion': <class 'torch.nn.modules.loss.MSELoss'>, 'optimizer': <class 'torch.optim.adamw.AdamW'>, 'lr': 0.00031021307432157666, 'max_epochs': 70, 'batch_size': 2, 'iterator_train': <class 'torch.utils.data.dataloader.DataLoader'>, 'iterator_valid': <class 'torch.utils.data.dataloader.DataLoader'>, 'dataset': <class 'skorch.dataset.Dataset'>, 'train_split': False, 'callbacks': [<autoemulate.emulators.neural_net_torch.InputShapeSetter object at 0x297371bd0>], 'predict_nonlinearity': 'auto', 'warm_start': False, 'verbose': 0, 'device': 'cpu', 'compile': False, 'use_caching': 'auto', '_params_to_validate': {'optimizer__weight_decay', 'module__input_size', 'module__hidden_sizes', 'module__output_size', 'iterator_train__shuffle', 'module__hidden_activation'}, 'module__input_size': 18, 'module__output_size': 4, 'optimizer__weight_decay': 0.0001, 'iterator_train__shuffle': True, 'module__hidden_activation': <class 'torch.nn.modules.activation.Tanh'>, 'module__hidden_sizes': (100, 100), 'callbacks__epoch_timer': <skorch.callbacks.logging.EpochTimer object at 0x29a787e10>, 'callbacks__train_loss': <skorch.callbacks.scoring.PassthroughScoring object at 0x29ae24ad0>, 'callbacks__train_loss__name': 'train_loss', 'callbacks__train_loss__lower_is_better': True, 'callbacks__train_loss__on_train': True, 'callbacks__valid_loss': <skorch.callbacks.scoring.PassthroughScoring object at 0x29b45dc50>, 'callbacks__valid_loss__name': 'valid_loss', 'callbacks__valid_loss__lower_is_better': True, 'callbacks__valid_loss__on_train': False, 'callbacks__InputShapeSetter': <autoemulate.emulators.neural_net_torch.InputShapeSetter object at 0x297371bd0>, 'callbacks__print_log': <skorch.callbacks.logging.PrintLog object at 0x29a7967d0>, 'callbacks__print_log__keys_ignored': None, 'callbacks__print_log__sink': <built-in function print>, 'callbacks__print_log__tablefmt': 'simple', 'callbacks__print_log__floatfmt': '.4f', 'callbacks__print_log__stralign': 'right'}
autoemulate - NeuralNetTorch is the best model with R^2 = 0.686
```

p.s. I notice the variation between runs (`em.compare()`) are quite big, are we setting a seed somewhere?