### PR TITLE
Setting up basic structure for FAQ

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -21,6 +21,10 @@ chapters:
   sections:
   - file: community/contributing
   - file: community/code-of-conduct
+  - file: community/faq/index
+    sections:
+    - file: community/faq/faq-users
+    - file: community/faq/faq-contributors
 
 - file: reference/index
   sections:

--- a/docs/community/faq/faq-contributors.md
+++ b/docs/community/faq/faq-contributors.md
@@ -1,0 +1,65 @@
+# First-Time Contributors' Frequently Asked Questions
+
+## Getting Started
+
+1. How can I contribute to AutoEmulate?
+   <!-- Overview of the ways to contribute, from code to documentation, and how to get started. -->
+
+2. What are the guidelines for contributing code?
+   <!-- Information on coding standards, the pull request process, and how contributions are reviewed. -->
+
+3. How do I choose what to work on for my first contribution?
+   <!-- Guidance on identifying beginner-friendly issues, selecting tasks based on personal expertise, or areas of the project that need the most help. -->
+
+4. What coding standards and practices does AutoEmulate follow?
+   <!-- Information on coding conventions, documentation standards, and testing practices contributors should adhere to. -->
+
+5. Are there any specific development tools or environments recommended for working on AutoEmulate?
+   <!-- Suggestions for IDEs, code editors, version control systems, or other tools that facilitate development and contribute to the project. -->
+
+## Making Contributions
+
+1. How do I submit a contribution, and what is the review process?
+   <!-- Step-by-step guide on creating pull requests, what happens after submission, how contributions are reviewed, and typical timelines for feedback. -->
+
+2. Can I contribute by writing documentation or tutorials, and how?
+   <!-- Details on how to contribute to the project's documentation, tutorial creation, or translation efforts, including style guides or templates to follow. -->
+
+3. What should I do if my pull request gets rejected or needs revision?
+   <!-- Advice on how to handle feedback on contributions, including how to make requested changes and resubmit for review. -->
+
+## Technical Questions
+
+1. How is the AutoEmulate project structured?
+   <!-- An introduction to the project's architecture and where contributors can find key components. -->
+
+2. How do I set up my development environment for AutoEmulate?
+   <!-- Steps to configure a local development environment, including any necessary tools or dependencies. -->
+
+3. How do I run tests for AutoEmulate?
+   <!-- Instructions on how to execute the project's test suite to ensure changes do not introduce regressions. -->
+
+## Community and Support
+
+1. Where can I ask questions if I'm stuck?
+   <!-- Information on where to find support, such as community forums, chat channels, or mailing lists. -->
+
+2. How does AutoEmulate handle contributions related to security issues?
+   <!-- Guidelines on reporting security vulnerabilities and how they are addressed by the project. -->
+
+3. Is there a code of conduct for contributors?
+   <!-- Details on the project's code of conduct, expectations for respectful and constructive interaction, and how to report violations. -->
+
+4. How can I get involved in decision-making or project planning as a contributor?
+   <!-- Explanation of how the project governance works, ways to participate in project roadmap discussions, and opportunities for contributors to influence development priorities. -->
+
+## Beyond Code Contributions
+
+1. Can I contribute without coding, for example, through design, marketing, or community management?
+   <!-- Overview of non-code contribution opportunities, including outreach efforts, event organisation, or community moderation. -->
+
+2. How does the project recognise or reward contributions?
+   <!-- Information on acknowledgment of contributions through all-contributors. -->
+
+3. Are there regular meetings or forums where contributors can discuss the project?
+   <!-- Schedule and formats of any regular contributor meetings, forums for discussion, or channels for real-time communication among contributors. -->

--- a/docs/community/faq/faq-users.md
+++ b/docs/community/faq/faq-users.md
@@ -1,0 +1,70 @@
+# First-Time Users' Frequently Asked Questions
+
+## General Questions
+
+1. What is AutoEmulate?
+   <!-- A brief description of what the package does, its main features, and its intended use case. -->
+
+2. How do I install AutoEmulate?
+   <!-- Step-by-step instructions on installing the package, including any dependencies that might be required. -->
+
+3. What are the prerequisites for using AutoEmulate?
+   <!-- Information on the knowledge or data required to effectively use AutoEmulate, such as familiarity with Python, machine learning concepts, or specific data formats. -->
+
+## Usage Questions
+
+1. How do I start using AutoEmulate with my data?
+   <!-- A simple example to get a new user started, possibly pointing to more detailed tutorials or documentation. -->
+
+2. What kind of data can I analyze with AutoEmulate?
+   <!-- Clarification on the types of datasets suitable for analysis, including data formats and recommended data sizes. -->
+
+3. How do I interpret the results from AutoEmulate?
+   <!-- Guidance on understanding the output of the software, including any metrics or visualizations it produces. -->
+
+4. Can I use AutoEmulate for commercial purposes?
+   <!-- Information on licensing and any restrictions on use. -->
+
+## Advanced Usage
+
+1. How can I customize simulations in AutoEmulate?
+   <!-- Explanation of how users can adjust parameters or settings to tailor simulations to their specific research questions. -->
+
+2. Does AutoEmulate support parallel processing or high-performance computing (HPC) environments?
+   <!-- Details on the software's capabilities to leverage multi-threading, distributed computing, or HPC resources to speed up computations. -->
+
+3. Can AutoEmulate be integrated with other data analysis or simulation tools?
+   <!-- Information on APIs, file formats, or protocols that facilitate the integration of AutoEmulate with other software ecosystems. -->
+
+## Data Handling
+
+1. What are the best practices for data preprocessing before using AutoEmulate?
+   <!-- Tips and recommendations on preparing data, including normalisation, dealing with missing values, or data segmentation. -->
+
+2. How does AutoEmulate handle large datasets?
+   <!-- Advice on managing large-scale data analyses, potential memory management features, or ways to streamline processing. -->
+
+3. Can I use AutoEmulate for real-time data analysis?
+   <!-- Insights into the software's ability to process data in real-time and any limitations or considerations. -->
+
+## Troubleshooting
+
+1. What common issues might I encounter when using AutoEmulate, and how can I solve them?
+   <!-- A list of frequently encountered problems with suggested solutions, possibly linked to a more extensive troubleshooting guide. -->
+
+2. How can I report a bug or request a feature in AutoEmulate?
+   <!-- Instructions on the proper channels for reporting issues or suggesting enhancements, including any templates or information to include. -->
+
+## Community and Learning Resources
+
+1. Are there any community projects or collaborations using AutoEmulate I can join or learn from?
+   <!-- Information on community-led projects, study groups, or collaborative research initiatives involving AutoEmulate. -->
+
+2. Where can I find tutorials or case studies on using AutoEmulate?
+   <!-- Directions to comprehensive learning materials, such as video tutorials (if we want to record that), written guides, or published research papers using AutoEmulate. -->
+
+3. How can I stay updated on new releases or updates to AutoEmulate?
+   <!-- Guidance on subscribing to newsletters when/if we will have that, community calls if we start that, following the project on social media if we want to create those platforms, or joining community forums/Slack once we have that ready... -->
+
+4. What support options are available if I need help with AutoEmulate?
+   <!-- Overview of support resources, including documentation, community forums/Slack when we have that ready... -->

--- a/docs/community/faq/index.md
+++ b/docs/community/faq/index.md
@@ -1,0 +1,30 @@
+# Frequently Asked Questions
+
+Welcome to the AutoEmulate Frequently Asked Questions (FAQ) page! This document is designed to assist both first-time users who are diving into AutoEmulate for their projects and new contributors looking to support the development of this innovative software. Whether you are exploring how to set up and run your first simulation, troubleshoot common issues, or you're interested in enhancing AutoEmulate with your contributions, this FAQ is here to provide you with quick and clear answers.
+
+Our goal is to make your experience with AutoEmulate as smooth and rewarding as possible. To facilitate this, we've compiled a list of questions and answers based on common queries we receive from our community. These are divided into sections tailored to users and contributors, alongside general information about AutoEmulate, to help you find the answers you need efficiently.
+
+If you're unsure where to start, we recommend using the search function (Ctrl+F or Command+F on most browsers) to quickly navigate to relevant topics. Additionally, each section is designed to be self-contained, allowing you to jump directly to the information that interests you the most.
+
+Remember, this FAQ is a collaborative effort, reflecting the inquiries and collective knowledge of our vibrant community. We welcome feedback and suggestions for new questions that you believe should be included. Together, we can make this resource even more valuable for everyone involved with AutoEmulate.
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card}
+:link: faq-users
+:link-type: doc
+**Users**.
+
+Are you a new user of AutoEmulate? Check out the frequently asked questions here.
+:::
+
+:::{grid-item-card}
+:link: faq-contributors
+:link-type: doc
+**Contributors**.
+
+Are you a new contributor to AutoEmulate's codebase? Check out the frequently asked questions here.
+:::
+
+::::


### PR DESCRIPTION
Adds a landing page for FAQ:

<img width="1057" alt="image" src="https://github.com/alan-turing-institute/autoemulate/assets/7298727/41992e44-44d6-4623-88e9-80f5b1c50a6a">

Clicking on FAQ for users takes you to a page with basic questions for new _users_ of the package:

<img width="1054" alt="image" src="https://github.com/alan-turing-institute/autoemulate/assets/7298727/4bc7fd67-18a8-40c4-b937-a08487f81ed6">

Clicking on FAQ for contributors takes you to a page with basic question on how to start contributing to the package:

<img width="1056" alt="image" src="https://github.com/alan-turing-institute/autoemulate/assets/7298727/eaed55e8-a35e-4304-98da-d8e02f5839ad">

Resolves #148.