### PR TITLE
Update Bayes search for NN modules

### DIFF
--- a/autoemulate/compare.py
+++ b/autoemulate/compare.py
@@ -201,6 +201,7 @@ class AutoEmulate:
             for i, model in enumerate(self.models):
                 model_name = get_model_name(model)
                 pbar.set_description(f"{pb_text} {model_name}")
+
                 try:
                     # hyperparameter search
                     if self.param_search:

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -30,7 +30,7 @@ class NeuralNetTorch(NeuralNetRegressor):
         criterion=torch.nn.MSELoss,
         optimizer=torch.optim.AdamW,
         lr: float = 1e-3,
-        batch_size: int = 128,
+        batch_size: int = 32,
         max_epochs: int = 1,
         module__input_size: int = None,
         module__output_size: int = None,

--- a/autoemulate/emulators/neural_net_torch.py
+++ b/autoemulate/emulators/neural_net_torch.py
@@ -69,6 +69,14 @@ class NeuralNetTorch(NeuralNetRegressor):
             self.module__input_size is not None and self.module__output_size is not None
         )
 
+    def initialize_optimizer(self, triggered_directly=None):
+        if self.optimizer == torch.optim.LBFGS and hasattr(
+            self, "optimizer__weight_decay"
+        ):
+            # LBFGS does not support weight_decay
+            del self.optimizer__weight_decay
+        return super().initialize_optimizer(triggered_directly)
+
     def initialize_module(self, reason=None):
         kwargs = self.get_params_for("module")
         if hasattr(self, "random_state"):

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -56,12 +56,12 @@ class MLPModule(TorchModule):
         match search_type:
             case "random":
                 param_space |= {
-                    "lr": loguniform(1e-6, 1e-4),
+                    "lr": loguniform(1e-6, 1e-3),
                 }
             case "bayes":
                 param_space |= {
                     "optimizer": Categorical(param_space["optimizer"]),
-                    "lr": Real(1e-6, 1e-4, prior="log-uniform"),
+                    "lr": Real(1e-6, 1e-3, prior="log-uniform"),
                 }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -50,7 +50,7 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
-            "optimizer": [torch.optim.SGD, torch.optim.AdamW, torch.optim.LBFGS],
+            "optimizer": [torch.optim.AdamW, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -56,12 +56,12 @@ class MLPModule(TorchModule):
         match search_type:
             case "random":
                 param_space |= {
-                    "lr": loguniform(1e-6, 1e-3),
+                    "lr": loguniform(1e-6, 1e-4),
                 }
             case "bayes":
                 param_space |= {
                     "optimizer": Categorical(param_space["optimizer"]),
-                    "lr": Real(1e-6, 1e-3, prior="log-uniform"),
+                    "lr": Real(1e-6, 1e-4, prior="log-uniform"),
                 }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -50,7 +50,7 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
-            "optimizer": [torch.optim.AdamW, torch.optim.SGD, torch.optim.LBFGS],
+            "optimizer": [torch.optim.AdamW, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -50,17 +50,17 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
+            "optimizer": [torch.optim.AdamW, torch.optim.SGD, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
                 param_space |= {
-                    "optimizer": [torch.optim.AdamW, torch.optim.SGD],
                     "lr": loguniform(1e-06, 1e-2),
                 }
             case "bayes":
                 param_space |= {
-                    "optimizer": Categorical([torch.optim.AdamW, torch.optim.SGD]),
+                    "optimizer": Categorical(param_space["optimizer"]),
                     "lr": Real(1e-06, 1e-2, prior="log-uniform"),
                 }
             case _:

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -50,18 +50,18 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
-            "optimizer": [torch.optim.AdamW, torch.optim.LBFGS],
+            "optimizer": [torch.optim.SGD, torch.optim.AdamW, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
                 param_space |= {
-                    "lr": loguniform(1e-06, 1e-2),
+                    "lr": loguniform(1e-6, 1e-4),
                 }
             case "bayes":
                 param_space |= {
                     "optimizer": Categorical(param_space["optimizer"]),
-                    "lr": Real(1e-06, 1e-2, prior="log-uniform"),
+                    "lr": Real(1e-6, 1e-4, prior="log-uniform"),
                 }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")

--- a/autoemulate/emulators/neural_networks/mlp.py
+++ b/autoemulate/emulators/neural_networks/mlp.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 import torch
 from scipy.stats import loguniform
-from skopt.space import Integer
+from skopt.space import Categorical
 from skopt.space import Real
 from torch import nn
 
@@ -50,14 +50,19 @@ class MLPModule(TorchModule):
                 nn.Sigmoid,
                 nn.GELU,
             ],
-            "optimizer": [torch.optim.AdamW, torch.optim.SGD],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
-                param_space |= {"lr": loguniform(1e-06, 1e-2)}
+                param_space |= {
+                    "optimizer": [torch.optim.AdamW, torch.optim.SGD],
+                    "lr": loguniform(1e-06, 1e-2),
+                }
             case "bayes":
-                param_space |= {"lr": Real(1e-06, 1e-2, prior="log-uniform")}
+                param_space |= {
+                    "optimizer": Categorical([torch.optim.AdamW, torch.optim.SGD]),
+                    "lr": Real(1e-06, 1e-2, prior="log-uniform"),
+                }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")
 

--- a/autoemulate/emulators/neural_networks/rbf.py
+++ b/autoemulate/emulators/neural_networks/rbf.py
@@ -330,12 +330,12 @@ class RBFModule(TorchModule):
         match search_type:
             case "random":
                 param_space |= {
-                    "lr": loguniform(1e-06, 1e-3),
+                    "lr": loguniform(1e-6, 1e-4),
                 }
             case "bayes":
                 param_space |= {
                     "optimizer": Categorical(param_space["optimizer"]),
-                    "lr": Real(1e-06, 1e-3, prior="log-uniform"),
+                    "lr": Real(1e-6, 1e-4, prior="log-uniform"),
                 }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")

--- a/autoemulate/emulators/neural_networks/rbf.py
+++ b/autoemulate/emulators/neural_networks/rbf.py
@@ -324,18 +324,18 @@ class RBFModule(TorchModule):
                 rbf_inverse_quadratic,
                 rbf_inverse_multiquadric,
             ],
-            "optimizer": [torch.optim.AdamW, torch.optim.SGD],
+            "optimizer": [torch.optim.SGD, torch.optim.AdamW, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
                 param_space |= {
-                    "lr": loguniform(1e-06, 1e-2),
+                    "lr": loguniform(1e-06, 1e-3),
                 }
             case "bayes":
                 param_space |= {
                     "optimizer": Categorical(param_space["optimizer"]),
-                    "lr": Real(1e-06, 1e-2, prior="log-uniform"),
+                    "lr": Real(1e-06, 1e-3, prior="log-uniform"),
                 }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")

--- a/autoemulate/emulators/neural_networks/rbf.py
+++ b/autoemulate/emulators/neural_networks/rbf.py
@@ -324,17 +324,17 @@ class RBFModule(TorchModule):
                 rbf_inverse_quadratic,
                 rbf_inverse_multiquadric,
             ],
+            "optimizer": [torch.optim.AdamW, torch.optim.SGD],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
                 param_space |= {
-                    "optimizer": [torch.optim.AdamW, torch.optim.SGD],
                     "lr": loguniform(1e-06, 1e-2),
                 }
             case "bayes":
                 param_space |= {
-                    "optimizer": Categorical([torch.optim.AdamW, torch.optim.SGD]),
+                    "optimizer": Categorical(param_space["optimizer"]),
                     "lr": Real(1e-06, 1e-2, prior="log-uniform"),
                 }
             case _:

--- a/autoemulate/emulators/neural_networks/rbf.py
+++ b/autoemulate/emulators/neural_networks/rbf.py
@@ -1,11 +1,9 @@
 from typing import Callable
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 import torch
 from scipy.stats import loguniform
-from skopt.space import Integer
+from skopt.space import Categorical
 from skopt.space import Real
 from torch import nn
 
@@ -326,14 +324,19 @@ class RBFModule(TorchModule):
                 rbf_inverse_quadratic,
                 rbf_inverse_multiquadric,
             ],
-            "optimizer": [torch.optim.AdamW, torch.optim.SGD],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:
             case "random":
-                param_space |= {"lr": loguniform(1e-06, 1e-2)}
+                param_space |= {
+                    "optimizer": [torch.optim.AdamW, torch.optim.SGD],
+                    "lr": loguniform(1e-06, 1e-2),
+                }
             case "bayes":
-                param_space |= {"lr": Real(1e-06, 1e-2, prior="log-uniform")}
+                param_space |= {
+                    "optimizer": Categorical([torch.optim.AdamW, torch.optim.SGD]),
+                    "lr": Real(1e-06, 1e-2, prior="log-uniform"),
+                }
             case _:
                 raise ValueError(f"Invalid search type: {search_type}")
 

--- a/autoemulate/emulators/neural_networks/rbf.py
+++ b/autoemulate/emulators/neural_networks/rbf.py
@@ -324,7 +324,7 @@ class RBFModule(TorchModule):
                 rbf_inverse_quadratic,
                 rbf_inverse_multiquadric,
             ],
-            "optimizer": [torch.optim.SGD, torch.optim.AdamW, torch.optim.LBFGS],
+            "optimizer": [torch.optim.AdamW, torch.optim.LBFGS],
             "optimizer__weight_decay": (1 / 10 ** np.arange(1, 9)).tolist(),
         }
         match search_type:

--- a/autoemulate/hyperparam_searching.py
+++ b/autoemulate/hyperparam_searching.py
@@ -23,6 +23,8 @@ def _optimize_params(
     param_space=None,
     n_jobs=None,
     logger=None,
+    error_score=np.nan,
+    verbose=0,
 ):
     """Performs hyperparameter search for the provided model.
 
@@ -49,7 +51,11 @@ def _optimize_params(
     n_jobs : int
         Number of jobs to run in parallel.
     logger : logging.Logger
-        Logger instance.
+        Logger instance
+    error_score: 'raise' or numeric
+        Value to assign to the score if an error occurs in estimator fitting.
+    verbose: int
+        Verbosity level for the searcher
 
     Returns
     -------
@@ -68,7 +74,8 @@ def _optimize_params(
             cv=cv,
             n_jobs=n_jobs,
             refit=True,
-            verbose=0,
+            error_score=error_score,
+            verbose=verbose,
         )
     # Bayes search
     elif search_type == "bayes":
@@ -79,7 +86,8 @@ def _optimize_params(
             cv=cv,
             n_jobs=n_jobs,
             refit=True,
-            verbose=0,
+            error_score=error_score,
+            verbose=verbose,
         )
     elif search_type == "grid":
         raise NotImplementedError("Grid search not available yet.")

--- a/autoemulate/hyperparam_searching.py
+++ b/autoemulate/hyperparam_searching.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 from sklearn.model_selection import RandomizedSearchCV
 from skopt import BayesSearchCV
 
@@ -7,6 +8,8 @@ from autoemulate.utils import _adjust_param_space
 from autoemulate.utils import get_model_name
 from autoemulate.utils import get_model_param_space
 from autoemulate.utils import get_model_params
+
+np.int = np.int64
 
 
 def _optimize_params(

--- a/autoemulate/hyperparam_searching.py
+++ b/autoemulate/hyperparam_searching.py
@@ -9,6 +9,7 @@ from autoemulate.utils import get_model_name
 from autoemulate.utils import get_model_param_space
 from autoemulate.utils import get_model_params
 
+# TODO remove this when skopt update numpy https://github.com/scikit-optimize/scikit-optimize/issues/1171
 np.int = np.int64
 
 

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -151,3 +151,20 @@ def test_nn_torch_module_ui_param_search():
     em.setup(X, y, model_subset=["NNMlp"], param_search=True, param_search_iters=2)
     # check that compare does not raise an error
     best = em.compare()
+
+
+def test_nn_torch_module_ui_param_search_bayes():
+    input_size, output_size = 10, 2
+    X = np.random.rand(10, input_size)
+    y = np.random.rand(10, output_size)
+    em = AutoEmulate()
+    em.setup(
+        X,
+        y,
+        model_subset=["NNMlp"],
+        param_search=True,
+        param_search_type="bayes",
+        param_search_iters=20,
+    )
+    # check that compare does not raise an error
+    best = em.compare()

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -5,8 +5,6 @@ from autoemulate.compare import AutoEmulate
 from autoemulate.emulators import NeuralNetTorch
 from autoemulate.utils import set_random_seed
 
-set_random_seed(1234)
-
 
 def test_nn_torch_initialisation():
     nn_torch = NeuralNetTorch()
@@ -119,6 +117,7 @@ def test_nn_torch_module_ui():
 
 
 def test_nn_torch_module_ui_param_search_random():
+    set_random_seed(1234)
     input_size, output_size = 10, 2
     X = np.random.rand(100, input_size)
     y = np.random.rand(100, output_size)
@@ -136,6 +135,7 @@ def test_nn_torch_module_ui_param_search_random():
 
 
 def test_nn_torch_module_ui_param_search_bayes():
+    set_random_seed(1234)
     input_size, output_size = 10, 2
     X = np.random.rand(10, input_size)
     y = np.random.rand(10, output_size)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -3,34 +3,9 @@ import pytest
 
 from autoemulate.compare import AutoEmulate
 from autoemulate.emulators import NeuralNetTorch
-from autoemulate.experimental_design import LatinHypercube
-from autoemulate.utils import get_model_name
+from autoemulate.utils import set_random_seed
 
-# def simple_sim(params):
-#     """A simple simulator."""
-#     x, y = params
-#     return x + 2 * y
-
-
-# # fixture for simulation input and output
-# @pytest.fixture(scope="module")
-# def simulation_io():
-#     """Setup for tests (Arrange)"""
-#     lh = LatinHypercube([(0.0, 1.0), (10.0, 100.0)])
-#     sim_in = lh.sample(10)
-#     sim_out = [simple_sim(p) for p in sim_in]
-#     return sim_in, sim_out
-
-
-# @pytest.fixture(scope="module")
-# def nn_torch_model(simulation_io):
-#     """Setup for tests (Arrange)"""
-#     sim_in, sim_out = simulation_io
-#     nn_torch = NeuralNetTorch(module="mlp")
-#     sim_in = sim_in.astype(np.float32)
-#     sim_out = np.array(sim_out, dtype=np.float32)
-#     nn_torch.fit(sim_in, sim_out)
-#     return nn_torch
+set_random_seed(1234)
 
 
 def test_nn_torch_initialisation():

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -143,12 +143,19 @@ def test_nn_torch_module_ui():
     best = em.compare()
 
 
-def test_nn_torch_module_ui_param_search():
+def test_nn_torch_module_ui_param_search_random():
     input_size, output_size = 10, 2
     X = np.random.rand(100, input_size)
     y = np.random.rand(100, output_size)
     em = AutoEmulate()
-    em.setup(X, y, model_subset=["NNMlp"], param_search=True, param_search_iters=2)
+    em.setup(
+        X,
+        y,
+        model_subset=["NNMlp"],
+        param_search=True,
+        param_search_type="random",
+        param_search_iters=5,
+    )
     # check that compare does not raise an error
     best = em.compare()
 
@@ -164,7 +171,7 @@ def test_nn_torch_module_ui_param_search_bayes():
         model_subset=["NNMlp"],
         param_search=True,
         param_search_type="bayes",
-        param_search_iters=20,
+        param_search_iters=5,
     )
     # check that compare does not raise an error
     best = em.compare()


### PR DESCRIPTION
- use `Categorical` to address https://github.com/alan-turing-institute/autoemulate/issues/199
- subsequently, we get following error due to deprecated reference to `np.int` in `skopt`. As a quick fix, I added `np.int=np.int64` in `hyperparam_searching.py`. There is an open issue on this https://github.com/scikit-optimize/scikit-optimize/issues/1171 on `skopt`.
  ```
  autoemulate - Failed to perform hyperparameter search on NNMlp
  Traceback (most recent call last):
    File "/Users/bryanlimy/Git/autoemulate/autoemulate/hyperparam_searching.py", line 91, in _optimize_params
      searcher.fit(X, y)
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/searchcv.py", line 466, in fit
      super().fit(X=X, y=y, groups=groups, **fit_params)
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/sklearn/base.py", line 1474, in wrapper
      return fit_method(estimator, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/sklearn/model_selection/_search.py", line 970, in fit
      self._run_search(evaluate_candidates)
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/searchcv.py", line 512, in _run_search
      optim_result = self._step(
                     ^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/searchcv.py", line 400, in _step
      params = optimizer.ask(n_points=n_points)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/optimizer/optimizer.py", line 395, in ask
      x = opt.ask()
          ^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/optimizer/optimizer.py", line 367, in ask
      return self._ask()
             ^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/optimizer/optimizer.py", line 434, in _ask
      return self.space.rvs(random_state=self.rng)[0]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/space.py", line 900, in rvs
      columns.append(dim.rvs(n_samples=n_samples, random_state=rng))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/space.py", line 698, in rvs
      return self.inverse_transform(list(choices))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/space.py", line 685, in inverse_transform
      inv_transform = super(Categorical, self).inverse_transform(Xt)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/space.py", line 168, in inverse_transform
      return self.transformer.inverse_transform(Xt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/transformers.py", line 309, in inverse_transform
      X = transformer.inverse_transform(X)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/skopt/space/transformers.py", line 275, in inverse_transform
      return np.round(X_orig).astype(np.int)
                                     ^^^^^^
    File "/opt/homebrew/Caskroom/miniforge/base/envs/autoemulate/lib/python3.11/site-packages/numpy/__init__.py", line 324, in __getattr__
      raise AttributeError(__former_attrs__[attr])
  AttributeError: module 'numpy' has no attribute 'int'.
  `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
      https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  ```
- Added `LBFGS` optimizer to NN modules to match with scikit-learn MLP, addressing https://github.com/alan-turing-institute/autoemulate/issues/192
- Updated `initialize_optimizer` to ignore `weight_decay` if `LBFGS` is used as it doesn't support weight decay in PyTorch.
- Lower the max learning rate for hyperparameter search to `1e-3` to avoid gradient exploding.
- Set `verbose=0` and `error_score=np.nan` in `_optimize_params` so that the values to `RandomizedSearchCV` and `BayesSearchCV` are the same. The default value of `error_score` to `RandomizedSearchCV` is `np.nan` which is different from the default value of `"raise"  in `BayesSearchCV`.