### PR TITLE
PyTorch model extractor

### DIFF
--- a/autoemulate/emulators/conditional_neural_process.py
+++ b/autoemulate/emulators/conditional_neural_process.py
@@ -213,6 +213,7 @@ class ConditionalNeuralProcess(RegressorMixin, BaseEstimator):
             verbose=0,
         )
         self.model_.fit(X, y)
+        self.is_fitted_ = True
         self.X_train_ = X
         self.y_train_ = y
         self.n_features_in_ = X.shape[1]

--- a/autoemulate/utils.py
+++ b/autoemulate/utils.py
@@ -402,7 +402,7 @@ def extract_pytorch_model(model):
     Returns
     -------
     torch.nn.Module
-        The underlying PyTorch model.
+        The underlying PyTorch model, in evaluation mode.
 
     Raises
     ------
@@ -456,4 +456,4 @@ def extract_pytorch_model(model):
             "and handle data preprocessing manually."
         )
 
-    return core_model.module_
+    return core_model.module_.eval()

--- a/tests/test_pytorch_utils.py
+++ b/tests/test_pytorch_utils.py
@@ -8,7 +8,7 @@ from sklearn.svm import SVR
 
 from autoemulate.emulators import GaussianProcess
 from autoemulate.emulators import RandomForest
-from autoemulate.utils import _extract_pytorch_model
+from autoemulate.utils import extract_pytorch_model
 
 
 @pytest.fixture
@@ -35,42 +35,42 @@ def Xy():
 # test_error_when_not_fitted
 def test_error_when_not_fitted(pytorch_model):
     with pytest.raises(ValueError):
-        _extract_pytorch_model(pytorch_model)
+        extract_pytorch_model(pytorch_model)
 
 
 # test standalone model
 def test_extract_when_fitted(pytorch_model, Xy):
     pytorch_model.fit(*Xy)
-    model = _extract_pytorch_model(pytorch_model)
+    model = extract_pytorch_model(pytorch_model)
     assert isinstance(model, torch.nn.Module)
 
 
 def test_error_when_not_pytorch_model(non_pytorch_model, Xy):
     non_pytorch_model.fit(*Xy)
     with pytest.raises(ValueError):
-        _extract_pytorch_model(non_pytorch_model)
+        extract_pytorch_model(non_pytorch_model)
 
 
 def test_error_when_multiout_model(non_pytorch_multiout_model, Xy):
     non_pytorch_multiout_model.fit(*Xy)
     with pytest.raises(ValueError):
-        _extract_pytorch_model(non_pytorch_multiout_model)
+        extract_pytorch_model(non_pytorch_multiout_model)
 
 
 # test pipeline
 def test_extract_when_fitted_pipeline(pytorch_model, Xy):
     pytorch_model.fit(*Xy)
-    model = _extract_pytorch_model(pytorch_model)
+    model = extract_pytorch_model(pytorch_model)
     assert isinstance(model, torch.nn.Module)
 
 
 def test_error_when_non_pytorch_pipeline(non_pytorch_model, Xy):
     non_pytorch_model.fit(*Xy)
     with pytest.raises(ValueError):
-        _extract_pytorch_model(non_pytorch_model)
+        extract_pytorch_model(non_pytorch_model)
 
 
 def test_error_when_multiout_pipeline(non_pytorch_multiout_model, Xy):
     non_pytorch_multiout_model.fit(*Xy)
     with pytest.raises(ValueError):
-        _extract_pytorch_model(non_pytorch_multiout_model)
+        extract_pytorch_model(non_pytorch_multiout_model)

--- a/tests/test_pytorch_utils.py
+++ b/tests/test_pytorch_utils.py
@@ -59,18 +59,28 @@ def test_error_when_multiout_model(non_pytorch_multiout_model, Xy):
 
 # test pipeline
 def test_extract_when_fitted_pipeline(pytorch_model, Xy):
+    pytorch_model = Pipeline([("model", pytorch_model)])
     pytorch_model.fit(*Xy)
     model = extract_pytorch_model(pytorch_model)
     assert isinstance(model, torch.nn.Module)
 
 
 def test_error_when_non_pytorch_pipeline(non_pytorch_model, Xy):
+    non_pytorch_model = Pipeline([("model", non_pytorch_model)])
     non_pytorch_model.fit(*Xy)
     with pytest.raises(ValueError):
         extract_pytorch_model(non_pytorch_model)
 
 
 def test_error_when_multiout_pipeline(non_pytorch_multiout_model, Xy):
+    non_pytorch_multiout_model = Pipeline([("model", non_pytorch_multiout_model)])
     non_pytorch_multiout_model.fit(*Xy)
     with pytest.raises(ValueError):
         extract_pytorch_model(non_pytorch_multiout_model)
+
+
+def test_warning_when_scaled_or_reduced(pytorch_model, Xy):
+    pytorch_model = Pipeline([("scaler", StandardScaler()), ("model", pytorch_model)])
+    pytorch_model.fit(*Xy)
+    with pytest.warns(UserWarning):
+        extract_pytorch_model(pytorch_model)

--- a/tests/test_pytorch_utils.py
+++ b/tests/test_pytorch_utils.py
@@ -79,8 +79,12 @@ def test_error_when_multiout_pipeline(non_pytorch_multiout_model, Xy):
         extract_pytorch_model(non_pytorch_multiout_model)
 
 
-def test_warning_when_scaled_or_reduced(pytorch_model, Xy):
+def test_warning_when_scaled_or_reduced(pytorch_model, Xy, capsys):
     pytorch_model = Pipeline([("scaler", StandardScaler()), ("model", pytorch_model)])
     pytorch_model.fit(*Xy)
-    with pytest.warns(UserWarning):
-        extract_pytorch_model(pytorch_model)
+    extract_pytorch_model(pytorch_model)
+    captured = capsys.readouterr()
+    assert (
+        "Warning: Data preprocessing is not included in the extracted model"
+        in captured.out
+    )

--- a/tests/test_pytorch_utils.py
+++ b/tests/test_pytorch_utils.py
@@ -88,3 +88,9 @@ def test_warning_when_scaled_or_reduced(pytorch_model, Xy, capsys):
         "Warning: Data preprocessing is not included in the extracted model"
         in captured.out
     )
+
+
+def test_pytorch_model_is_in_eval_mode(pytorch_model, Xy):
+    pytorch_model.fit(*Xy)
+    model = extract_pytorch_model(pytorch_model)
+    assert not model.training

--- a/tests/test_pytorch_utils.py
+++ b/tests/test_pytorch_utils.py
@@ -1,0 +1,76 @@
+import pytest
+import torch
+from sklearn.datasets import make_regression
+from sklearn.multioutput import MultiOutputRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVR
+
+from autoemulate.emulators import GaussianProcess
+from autoemulate.emulators import RandomForest
+from autoemulate.utils import _extract_pytorch_model
+
+
+@pytest.fixture
+def pytorch_model():
+    return GaussianProcess()
+
+
+@pytest.fixture
+def non_pytorch_model():
+    return RandomForest()
+
+
+@pytest.fixture
+def non_pytorch_multiout_model():
+    return MultiOutputRegressor(SVR())
+
+
+@pytest.fixture
+def Xy():
+    X, y = make_regression(n_samples=100, n_features=3, n_targets=2)
+    return X, y
+
+
+# test_error_when_not_fitted
+def test_error_when_not_fitted(pytorch_model):
+    with pytest.raises(ValueError):
+        _extract_pytorch_model(pytorch_model)
+
+
+# test standalone model
+def test_extract_when_fitted(pytorch_model, Xy):
+    pytorch_model.fit(*Xy)
+    model = _extract_pytorch_model(pytorch_model)
+    assert isinstance(model, torch.nn.Module)
+
+
+def test_error_when_not_pytorch_model(non_pytorch_model, Xy):
+    non_pytorch_model.fit(*Xy)
+    with pytest.raises(ValueError):
+        _extract_pytorch_model(non_pytorch_model)
+
+
+def test_error_when_multiout_model(non_pytorch_multiout_model, Xy):
+    non_pytorch_multiout_model.fit(*Xy)
+    with pytest.raises(ValueError):
+        _extract_pytorch_model(non_pytorch_multiout_model)
+
+
+# test pipeline
+def test_extract_when_fitted_pipeline(pytorch_model, Xy):
+    pytorch_model.fit(*Xy)
+    model = _extract_pytorch_model(pytorch_model)
+    assert isinstance(model, torch.nn.Module)
+
+
+def test_error_when_non_pytorch_pipeline(non_pytorch_model, Xy):
+    non_pytorch_model.fit(*Xy)
+    with pytest.raises(ValueError):
+        _extract_pytorch_model(non_pytorch_model)
+
+
+def test_error_when_multiout_pipeline(non_pytorch_multiout_model, Xy):
+    non_pytorch_multiout_model.fit(*Xy)
+    with pytest.raises(ValueError):
+        _extract_pytorch_model(non_pytorch_multiout_model)


### PR DESCRIPTION
- adds a function to extract PyTorch models from `AutoEmulate` emulators
- emulators can be `pipelines`, `MultiOutputRegressors` etc., this function checks all the options and extracts the underlying PyTorch model where possible and throws an error for other models
- it also gives a message saying that datapreprocessing is better turned off when doing this and has to be done manually (as it can't be attached to the `PyTorch` model like it can be to a `sci-kit learn` model using a `pipeline`
- it returns the model in `eval` mode

- does _not_ yet include other objects as discussed in #291 . Maybe we leave that to the next PR?