### PR TITLE
Minor docs update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 - 🪄 **Low-Code**: Data-processing, model comparison, cross-validation, hyperparameter search and more in few lines of code
 - 🎯 **Optimized for Emulation**: Optimized for typical emulation scenarios with small to medium datasets (100s-1000s of points) with many inputs and outputs
 - 🔌 **Easy Integration**: All emulators are `scikit-learn` compatible, and the underlying `PyTorch` models can be extracted for custom use
-- 🔮 **Downstream Applications**: Still early days, but we've got prediction, sensitivity analysis, history matching and more
+- 🔮 **Downstream Applications**: Still early days, but we've got prediction, sensitivity analysis, calibration and more
 
 ## 🎓 State-of-the-Art Models
 

--- a/docs/tutorials/01_start.ipynb
+++ b/docs/tutorials/01_start.ipynb
@@ -539,7 +539,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# History Matching\n",
+    "# Downstream tasks\n",
+    "\n",
+    "Once you have a trained emulator, it can be used for many downstream tasks like calibration or sensitivity analysis. `AutoEmulate` comes with inbuilt support for some of the most common of these."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## History Matching\n",
     "\n",
     "In this section, we perform History Matching on the predictions from the best_emulator. This allows us to see which reagions of the parameter space are plausible. The Implausibility metric is calculated using the following relation for each set of parameter:\n",
     "\n",
@@ -591,7 +600,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #332 

This PR does a minor restructures of the intro tutorial so that "History Matching" is a subsection of a "Downstream tasks" section rather than a standalone section on its own. This has the implication that we add more examples here as we add them to the library.