### PR TITLE
Update pyright config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 # Quarto
 README.html
 README_files/
+
+# Ignore pyrightconfig.json to enable custom venv to be set
+pyrightconfig.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,8 @@ build-backend = "poetry.core.masonry.api"
 [tool.coverage.run]
 relative_files = true
 source = [".", "/tmp"]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+include = ["autoemulate/experimental/*", "tests/experimental/*"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,0 @@
-{
-    "venvPath": ".",
-    "venv": ".venv",
-    "include": ["autoemulate/experimental/*", "tests/experimental/*"]
-  }


### PR DESCRIPTION
This PR:
- Updates pyright config to be in `pyproject.toml` by default
- Removes `pyrightconfig.json` from git and adds to `.gitignore`

This enables custom venv to be set for pyright by creating a file `pyrightconfig.json` and setting the `venvPath`, `venv` and `include` variables.