### PR TITLE
Update ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
     hooks:
     - id: black
       language_version: python3
-      exclude: "^autoemulate/experimental|^tests/experimental"
+      exclude: "^autoemulate/experimental/|^tests/experimental/"
 -   repo: https://github.com/asottile/reorder-python-imports
     rev: v3.12.0
     hooks:
     -   id: reorder-python-imports
-        exclude: "^autoemulate/experimental|^tests/experimental"
+        exclude: "^autoemulate/experimental/|^tests/experimental/"
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: v0.11.2
@@ -17,14 +17,14 @@ repos:
     # Run the linter.
     - id: ruff
       types_or: [ python, pyi ]
-      files: ^autoemulate/experimental|^tests/experimental
+      files: ^autoemulate/experimental/|^tests/experimental/
       args: [--fix]
     # Run the formatter.
     - id: ruff-format
       types_or: [ python, pyi ]
-      files: ^autoemulate/experimental|^tests/experimental
+      files: ^autoemulate/experimental/|^tests/experimental/
 - repo: https://github.com/RobertCraigie/pyright-python
   rev: v1.1.398
   hooks:
   - id: pyright
-    files: ^autoemulate/experimental/|^tests/experimental
+    files: ^autoemulate/experimental/|^tests/experimental/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,17 +12,17 @@ repos:
         exclude: "^autoemulate/experimental/|^tests/experimental/"
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.2
+  rev: v0.11.4
   hooks:
-    # Run the linter.
-    - id: ruff
-      types_or: [ python, pyi ]
-      files: ^autoemulate/experimental/|^tests/experimental/
-      args: [--fix]
-    # Run the formatter.
-    - id: ruff-format
-      types_or: [ python, pyi ]
-      files: ^autoemulate/experimental/|^tests/experimental/
+  # Run the linter.
+  - id: ruff
+    types_or: [ python, pyi ]
+    args: [ --fix ]
+    files: ^autoemulate/experimental/|^tests/experimental/
+  # Run the formatter.
+  - id: ruff-format
+    types_or: [ python, pyi ]
+    files: ^autoemulate/experimental/|^tests/experimental/
 - repo: https://github.com/RobertCraigie/pyright-python
   rev: v1.1.398
   hooks:

--- a/autoemulate/experimental/data/preprocessors.py
+++ b/autoemulate/experimental/data/preprocessors.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-import torch
 
+import torch
 from autoemulate.experimental.types import InputLike
 
 

--- a/autoemulate/experimental/data/utils.py
+++ b/autoemulate/experimental/data/utils.py
@@ -1,8 +1,7 @@
 import numpy as np
 import torch
-from torch.utils.data import DataLoader, Dataset, TensorDataset, random_split
-
 from autoemulate.experimental.types import InputLike
+from torch.utils.data import DataLoader, Dataset, TensorDataset, random_split
 
 
 class InputTypeMixin:
@@ -32,7 +31,8 @@ class InputTypeMixin:
             dataset = x
         else:
             raise ValueError(
-                f"Unsupported type for x ({type(x)}). Must be numpy array or PyTorch tensor."
+                f"Unsupported type for x ({type(x)}). Must be numpy array or PyTorch "
+                "tensor."
             )
 
         return dataset
@@ -78,7 +78,8 @@ class InputTypeMixin:
         """
         if train_size < 0.0 or train_size > 1.0 or test_size < 0.0 or test_size > 1.0:
             raise ValueError(
-                f"Train size ({train_size}) and test size ({test_size}) must be specified as a proportion between 0 and 1"
+                f"Train size ({train_size}) and test size ({test_size}) must be "
+                "specified as a proportion between 0 and 1"
             )
         if test_size + train_size != 1.0:
             raise ValueError(
@@ -96,5 +97,7 @@ class InputTypeMixin:
     #     if isinstance(y, np.ndarray):
     #         y = torch.tensor(y, dtype=torch.float32)
     #     else:
-    #         raise ValueError("Unsupported type for X. Must be numpy array, PyTorch tensor")
+    #         raise ValueError(
+    #             "Unsupported type for X. Must be numpy array, PyTorch tensor"
+    #         )
     #     return y

--- a/autoemulate/experimental/emulators/base.py
+++ b/autoemulate/experimental/emulators/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from torch import nn
 
@@ -28,7 +29,8 @@ class Emulator(ABC):
     @abstractmethod
     def get_tune_config() -> TuneConfig:
         """
-        The keys in the TuneConfig must be implemented as keyword arguments in the __init__ method of any subclasses.
+        The keys in the TuneConfig must be implemented as keyword arguments in the
+        __init__ method of any subclasses.
 
         e.g.
 
@@ -63,7 +65,7 @@ class PyTorchBackend(nn.Module, Emulator, InputTypeMixin, Preprocessor):
     batch_size: int = 16
     shuffle: bool = True
     epochs: int = 10
-    loss_history: list[float] = []
+    loss_history: ClassVar[list[float]] = []
     verbose: bool = False
     preprocessor: Preprocessor | None = None
 
@@ -144,7 +146,8 @@ class PyTorchBackend(nn.Module, Emulator, InputTypeMixin, Preprocessor):
         return self(x)
 
     def cross_validate(self, x: InputLike) -> None:
-        raise NotImplementedError("This function is not yet implemented.")
+        msg = "This function is not yet implemented."
+        raise NotImplementedError(msg)
 
     @staticmethod
     def get_tune_config():

--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torchmetrics
 from sklearn.model_selection import BaseCrossValidator
 from torch.utils.data import DataLoader, Dataset, Subset
 
@@ -9,7 +10,6 @@ from autoemulate.experimental.types import (
     OutputLike,
     TensorLike,
 )
-import torchmetrics
 
 
 def _update(

--- a/autoemulate/experimental/types.py
+++ b/autoemulate/experimental/types.py
@@ -1,6 +1,6 @@
 from typing import Any
-import numpy as np
 
+import numpy as np
 import torch
 import torch.utils
 import torch.utils.data

--- a/autoemulate/experimental_design.py
+++ b/autoemulate/experimental_design.py
@@ -1,4 +1,5 @@
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 
 import mogp_emulator
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,48 @@ source = [".", "/tmp"]
 venvPath = "."
 venv = ".venv"
 include = ["autoemulate/experimental/*", "tests/experimental/*"]
+
+[tool.ruff]
+src = ["autoemulate/"]
+line-length = 88
+include = ["autoemulate/experimental/**/*.py", "tests/experimental/**/*.py"]
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "W",   # flake8
+    "B",   # flake8-bugbear
+    "I",   # isort
+    "ARG", # flake8-unused-arguments
+    "C4",  # flake8-comprehensions
+    "EM",  # flake8-errmsg
+    "ICN", # flake8-import-conventions
+    "ISC", # flake8-implicit-str-concat
+    "G",   # flake8-logging-format
+    "PGH", # pygrep-hooks
+    "PIE", # flake8-pie
+    "PL",  # pylint
+    "PT",  # flake8-pytest-style
+    "RET", # flake8-return
+    "RUF", # Ruff-specific
+    "SIM", # flake8-simplify
+    "UP",  # pyupgrade
+    "YTT", # flake8-2020
+    "EXE", # flake8-executable
+]
+
+ignore = [
+    "PLR2004", # Magic value used in comparison
+    "EM102",   # Exception must not use an f-string literal, assign to variable first
+    "ISC001",  # Conflicts with formatter
+]
+
+unfixable = [
+    "F401", # Would remove unused imports
+    "F841", # Would remove unused variables
+]
+flake8-unused-arguments.ignore-variadic-names = true # allow unused *args/**kwargs

--- a/tests/experimental/test_experimental_base.py
+++ b/tests/experimental/test_experimental_base.py
@@ -1,12 +1,11 @@
 import numpy as np
 import pytest
 import torch
-from torch import nn, optim
-from torch.utils.data import DataLoader, TensorDataset
-
+from autoemulate.experimental.data.preprocessors import Standardizer
 from autoemulate.experimental.emulators.base import InputTypeMixin, PyTorchBackend
 from autoemulate.experimental.tuner import Tuner
-from autoemulate.experimental.data.preprocessors import Standardizer
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
 
 # @pytest.fixture
 # def model_config() -> M:
@@ -173,10 +172,10 @@ class TestPyTorchBackend:
         )
 
     def test_standardizer_fail(self):
+        x_train = torch.Tensor([0.1, 2.0, 6.0, 0.2])
         with pytest.raises(
             ValueError, match="Expected 2D torch.Tensor, actual shape dim 1"
         ):
-            x_train = torch.Tensor([0.1, 2.0, 6.0, 0.2])
             self.model.preprocess(x_train)
 
     def test_tune_dataset(self):

--- a/tests/experimental/test_experimental_model_selection.py
+++ b/tests/experimental/test_experimental_model_selection.py
@@ -1,10 +1,9 @@
 import numpy as np
 import torch
-from sklearn.model_selection import KFold, LeavePOut
-from torch.utils.data import TensorDataset
-
 from autoemulate.experimental.emulators.base import Emulator
 from autoemulate.experimental.model_selection import cross_validate
+from sklearn.model_selection import KFold, LeavePOut
+from torch.utils.data import TensorDataset
 
 
 def test_cross_validate():


### PR DESCRIPTION
This PR adds and applies lints for ruff from [python-project-template](https://github.com/alan-turing-institute/python-project-template).

Since we're still early in the refactor process, this addition might be helpful for guiding the style/design of new code we're adding.