### PR TITLE
Cross validate with torchmetrics

### DIFF
--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -29,14 +29,14 @@ def _update(
     ):
         metric.update(y_true, y_pred)
     else:
-        raise ValueError(f"Score not implmented for {type(y_pred)}")
+        raise ValueError(f"Metric not implmented for {type(y_pred)}")
 
 
 def evaluate(
     y_true: InputLike, y_pred: OutputLike, metric: type[torchmetrics.Metric]
 ) -> float:
     """
-    Evaluate Emulator prediction performance using a `score_f` metric.
+    Evaluate Emulator prediction performance using a `torchmetrics.Metric`.
 
     Parameters
     ----------

--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -54,7 +54,7 @@ def evaluate(
 
     metric_instance = metric()
     _update(y_true, y_pred, metric_instance)
-    return metric_instance.compute().detach().numpy().item()
+    return metric_instance.compute().item()
 
 
 def cross_validate(
@@ -82,7 +82,7 @@ def cross_validate(
        Contains r2 and rmse scores computed for each cross validation fold.
     """
     cv_results = {"r2": [], "rmse": []}
-    for train_idx, val_idx in cv.split(dataset):
+    for train_idx, val_idx in cv.split(dataset):  # type: ignore TODO: identify type handling here
         # create train/val data subsets
         # convert idx to list to satisfy type checker
         train_subset = Subset(dataset, train_idx.tolist())
@@ -102,8 +102,8 @@ def cross_validate(
             _update(y_batch, y_batch_pred, mse_metric)
 
         # compute and save results
-        r2 = r2_metric.compute().detach().numpy().item()
-        rmse = np.sqrt(mse_metric.compute().detach().numpy().item())
+        r2 = r2_metric.compute().item()
+        rmse = np.sqrt(mse_metric.compute().item())
         cv_results["r2"].append(r2)
         cv_results["rmse"].append(rmse)
     return cv_results

--- a/poetry.lock
+++ b/poetry.lock
@@ -1528,6 +1528,29 @@ pandas = ["pandas (>=0.24.0)"]
 scikit-learn = ["scikit-learn (!=0.22.0)"]
 
 [[package]]
+name = "lightning-utilities"
+version = "0.14.3"
+description = "Lightning toolbox for across the our ecosystem."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "lightning_utilities-0.14.3-py3-none-any.whl", hash = "sha256:4ab9066aa36cd7b93a05713808901909e96cc3f187ea6fd3052b2fd91313b468"},
+    {file = "lightning_utilities-0.14.3.tar.gz", hash = "sha256:37e2f83f273890052955a44054382c211a303012ee577619efbaa5df9e65e9f5"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+setuptools = "*"
+typing_extensions = "*"
+
+[package.extras]
+cli = ["fire"]
+docs = ["requests (>=2.0.0)"]
+typing = ["fire", "mypy (>=1.0.0)", "types-setuptools"]
+
+[[package]]
 name = "linear-operator"
 version = "0.5.2"
 description = "A linear operator implementation, primarily designed for finite-dimensional positive definite operators (i.e. kernel matrices)."
@@ -3319,7 +3342,7 @@ version = "69.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
     {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
@@ -4069,6 +4092,37 @@ opt-einsum = ["opt-einsum (>=3.3)"]
 optree = ["optree (>=0.9.1)"]
 
 [[package]]
+name = "torchmetrics"
+version = "1.7.1"
+description = "PyTorch native Metrics"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "torchmetrics-1.7.1-py3-none-any.whl", hash = "sha256:9a4c45edbd0a1844cc1540c9e71bfbe0ee783a2ed997344d947fefecac90dbb9"},
+    {file = "torchmetrics-1.7.1.tar.gz", hash = "sha256:0ac1a0e90d2375866ceb5d3868720c6df7d7d0c5729b7ad36e92c897c6af70c2"},
+]
+
+[package.dependencies]
+lightning-utilities = ">=0.8.0"
+numpy = ">1.20.0"
+packaging = ">17.1"
+torch = ">=2.0.0"
+
+[package.extras]
+all = ["SciencePlots (>=2.0.0)", "einops (>=0.7.0)", "gammatone (>=1.0.0)", "ipadic (>=1.0.0)", "librosa (>=0.10.0)", "matplotlib (>=3.6.0)", "mecab-python3 (>=1.0.6)", "mypy (==1.15.0)", "nltk (>3.8.1)", "onnxruntime (>=1.12.0)", "pesq (>=0.0.4)", "piq (<=0.8.0)", "pycocotools (>2.0.0)", "pystoi (>=0.4.0)", "regex (>=2021.9.24)", "requests (>=2.19.0)", "scipy (>1.0.0)", "sentencepiece (>=0.2.0)", "timm (>=0.9.0)", "torch (==2.6.0)", "torch-fidelity (<=0.4.0)", "torch_linear_assignment (>=0.0.2)", "torchaudio (>=2.0.1)", "torchvision (>=0.15.1)", "torchvision (>=0.15.1)", "tqdm (<4.68.0)", "transformers (>4.4.0)", "transformers (>=4.42.3)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate"]
+audio = ["gammatone (>=1.0.0)", "librosa (>=0.10.0)", "onnxruntime (>=1.12.0)", "pesq (>=0.0.4)", "pystoi (>=0.4.0)", "requests (>=2.19.0)", "torchaudio (>=2.0.1)"]
+clustering = ["torch_linear_assignment (>=0.0.2)"]
+detection = ["pycocotools (>2.0.0)", "torchvision (>=0.15.1)"]
+dev = ["PyTDC (==0.4.1)", "SciencePlots (>=2.0.0)", "aeon (>=1.0.0)", "bert_score (==0.3.13)", "dists-pytorch (==0.1)", "dython (==0.7.9)", "einops (>=0.7.0)", "fairlearn", "fast-bss-eval (>=0.1.0)", "faster-coco-eval (>=1.6.3)", "gammatone (>=1.0.0)", "huggingface-hub (<0.31)", "ipadic (>=1.0.0)", "jiwer (>=2.3.0)", "kornia (>=0.6.7)", "librosa (>=0.10.0)", "lpips (<=0.1.4)", "matplotlib (>=3.6.0)", "mecab-ko (>=1.0.0,<1.1.0)", "mecab-ko-dic (>=1.0.0)", "mecab-python3 (>=1.0.6)", "mir-eval (>=0.6)", "monai (==1.4.0)", "mypy (==1.15.0)", "netcal (>1.0.0)", "nltk (>3.8.1)", "numpy (<2.3.0)", "onnxruntime (>=1.12.0)", "pandas (>1.4.0)", "permetrics (==2.0.0)", "pesq (>=0.0.4)", "piq (<=0.8.0)", "pycocotools (>2.0.0)", "pystoi (>=0.4.0)", "pytorch-msssim (==1.0.0)", "regex (>=2021.9.24)", "requests (>=2.19.0)", "rouge-score (>0.1.0)", "sacrebleu (>=2.3.0)", "scikit-image (>=0.19.0)", "scipy (>1.0.0)", "scipy (>1.0.0)", "sentencepiece (>=0.2.0)", "sewar (>=0.4.4)", "statsmodels (>0.13.5)", "timm (>=0.9.0)", "torch (==2.6.0)", "torch-fidelity (<=0.4.0)", "torch_complex (<0.5.0)", "torch_linear_assignment (>=0.0.2)", "torchaudio (>=2.0.1)", "torchvision (>=0.15.1)", "torchvision (>=0.15.1)", "tqdm (<4.68.0)", "transformers (>4.4.0)", "transformers (>=4.42.3)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate"]
+image = ["scipy (>1.0.0)", "torch-fidelity (<=0.4.0)", "torchvision (>=0.15.1)"]
+multimodal = ["einops (>=0.7.0)", "piq (<=0.8.0)", "timm (>=0.9.0)", "transformers (>=4.42.3)"]
+text = ["ipadic (>=1.0.0)", "mecab-python3 (>=1.0.6)", "nltk (>3.8.1)", "regex (>=2021.9.24)", "sentencepiece (>=0.2.0)", "tqdm (<4.68.0)", "transformers (>4.4.0)"]
+typing = ["mypy (==1.15.0)", "torch (==2.6.0)", "types-PyYAML", "types-emoji", "types-protobuf", "types-requests", "types-setuptools", "types-six", "types-tabulate"]
+visual = ["SciencePlots (>=2.0.0)", "matplotlib (>=3.6.0)"]
+
+[[package]]
 name = "tornado"
 version = "6.4"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -4319,4 +4373,4 @@ docs = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "6132be6dc2c0fbe9c1ef0eefee7e7c0dae3b66b96a131577b10607aed5d99701"
+content-hash = "14d0700c434912c6751208313f99b60cce93c08cd89c30c8f270a723578d8c2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ lightgbm = "^4.3.0"
 ipywidgets = "^8.1.2"
 gpytorch = "^1.12"
 salib = "^1.5.1"
+torchmetrics = "^1.7.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/experimental/test_experimental_base.py
+++ b/tests/experimental/test_experimental_base.py
@@ -103,7 +103,8 @@ class TestPyTorchBackend:
             self.linear = nn.Linear(1, 1)
             self.loss_fn = nn.MSELoss()
             self.optimizer = optim.SGD(self.parameters(), lr=0.01)
-
+            self.epochs = kwargs.get("epochs", 10)
+            self.batch_size = kwargs.get("batch_size", 16)
             self.preprocessor = Standardizer(
                 torch.Tensor([[-0.5]]), torch.Tensor([[0.5]])
             )
@@ -115,6 +116,7 @@ class TestPyTorchBackend:
         def get_tune_config():
             return {
                 "epochs": [100, 200, 300],
+                "batch_size": [16],
             }
 
     def setup_method(self):
@@ -154,8 +156,8 @@ class TestPyTorchBackend:
         """
         Test that Tuner accepts X,Y inputs.
         """
-        x_train = torch.Tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
-        y_train = torch.Tensor([[2.0], [4.0], [6.0], [8.0], [10.0]])
+        x_train = torch.Tensor(np.arange(16).reshape(-1, 1))
+        y_train = 2 * x_train
         tuner = Tuner(x_train, y_train, n_iter=10)
         tuner.run(self.DummyModel)
 
@@ -181,8 +183,8 @@ class TestPyTorchBackend:
         """
         Test that Tuner accepts a single Dataset input.
         """
-        x_train = torch.Tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
-        y_train = torch.Tensor([[2.0], [4.0], [6.0], [8.0], [10.0]])
+        x_train = torch.Tensor(np.arange(16).reshape(-1, 1))
+        y_train = 2 * x_train
         dataset = self.model._convert_to_dataset(x_train, y_train)
         tuner = Tuner(x=dataset, y=None, n_iter=10)
         tuner.run(self.DummyModel)

--- a/tests/experimental/test_experimental_model_selection.py
+++ b/tests/experimental/test_experimental_model_selection.py
@@ -1,5 +1,6 @@
+import numpy as np
 import torch
-from sklearn.model_selection import KFold, LeaveOneOut
+from sklearn.model_selection import KFold
 from torch.utils.data import TensorDataset
 
 from autoemulate.experimental.emulators.base import Emulator
@@ -22,7 +23,7 @@ def test_cross_validate():
         def get_tune_config():
             return {}
 
-    x = torch.tensor([1, 2, 3, 4, 5])
+    x = torch.tensor(np.arange(128)).float()
     y = 2 * x
     dataset = TensorDataset(x, y)
 
@@ -35,7 +36,8 @@ def test_cross_validate():
     assert len(results["r2"]) == 2
     assert len(results["rmse"]) == 2
 
-    # LOO
-    results = cross_validate(LeaveOneOut(), dataset, emulator)
-    assert len(results["r2"]) == 5
-    assert len(results["rmse"]) == 5
+    # LOO raised an error with torchmetrics R2Score since it requires at least 2 samples
+    # KFold with more splits
+    results = cross_validate(KFold(n_splits=x.shape[0] // 2), dataset, emulator)
+    assert len(results["r2"]) == x.shape[0] // 2
+    assert len(results["rmse"]) == x.shape[0] // 2


### PR DESCRIPTION
This PR explores an option to:
- using torchmetrics `Metric` in place of sklearn callable metrics
- evaluating over batches