### PR TITLE
Several easy docs fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ These Contributing Guidelines have been adapted from the [Contributing Guideline
 
 ## Get in touch
 
-**Email**: For any inquiries, please reach out to lead Developer Martin Stoffel, <mstoffel@turing.ac.uk>.
+Please visit our [GitHub repository](https://github.com/alan-turing-institute/autoemulate) and open an issue or discussion.
 
 <!-- The easiest way to get involved with the active development of AutoEmulate is to join our regular community calls. The community calls are currently on a hiatus but if you are interested in participating in the forthcoming community calls, which will start in 2024, you should join our Slack workspace, where conversation about when to hold the community calls in the future will take place. -->
 

--- a/README.md
+++ b/README.md
@@ -9,70 +9,11 @@
 <!-- SPHINX-START -->
 Simulations of physical systems are often slow and need lots of compute, which makes them unpractical for real-world applications like digital twins, or when they have to run thousands of times for sensitivity analyses. The goal of `AutoEmulate` is to make it easy to replace simulations with fast, accurate emulators. To do this, `AutoEmulate` automatically fits and compares various emulators, ranging from simple models like Radial Basis Functions and Second Order Polynomials to more complex models like Support Vector Machines, Gaussian Processes and Conditional Neural Processes to find the best emulator for a simulation. 
 
-The project is in early development. 
-
-## Installation
-
-`AutoEmulate` requires Python `>=3.10` and `<3.13`.
-
-There's lots of development at the moment, so we recommend installing the most current version from GitHub:
-
-```bash
-pip install git+https://github.com/alan-turing-institute/autoemulate.git
-```
-
-There's also a release on PyPI:
-
-```bash
-pip install autoemulate
-```
-
-For contributors using [Poetry](https://python-poetry.org/):
-
-```bash
-git clone https://github.com/alan-turing-institute/autoemulate.git
-cd autoemulate
-poetry install
-```
-
-## Quick start
-
-```python
-import numpy as np
-from autoemulate.compare import AutoEmulate
-from autoemulate.experimental_design import LatinHypercube
-from autoemulate.simulations.projectile import simulate_projectile
-
-# sample from a simulation
-lhd = LatinHypercube([(-5., 1.), (0., 1000.)])
-X = lhd.sample(100)
-y = np.array([simulate_projectile(x) for x in X])
-
-# compare emulators
-ae = AutoEmulate()
-ae.setup(X, y)
-best_emulator = ae.compare() 
-
-# cross-validation results
-ae.summarise_cv() 
-ae.plot_cv()
-
-# test set results for the best emulator
-ae.evaluate(best_emulator) 
-ae.plot_eval(best_emulator)
-
-# refit on full data and emulate!
-emulator = ae.refit(best_emulator) 
-emulator.predict(X)
-
-# global sensitivity analysis
-si = ae.sensitivity_analysis(emulator)
-ae.plot_sensitivity_analysis(si)
-```
+⚠️ Warning: This is an early version of the package and is still under development. We are working on improving the documentation and adding more features. If you have any questions or suggestions, please open an issue or a pull request.
 
 ## Documentation
 
-You can find tutorials, FAQs and the API reference [here](https://alan-turing-institute.github.io/autoemulate/). The documentation is still work in progress.
+You can find the project documentation [here](https://alan-turing-institute.github.io/autoemulate/), including [installation](https://alan-turing-institute.github.io/autoemulate/getting-started/installation.html).
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Simulations of physical systems are often slow and need lots of compute, which m
 
 You can find the project documentation [here](https://alan-turing-institute.github.io/autoemulate/), including [installation](https://alan-turing-institute.github.io/autoemulate/getting-started/installation.html).
 
+## The AutoEmulate project
+
+- The AutoEmulate project is run out of the [Alan Turing Institute](https://www.turing.ac.uk/).
+- Visit [autoemulate.com](https://www.autoemulate.com/) to learn more.
+- We have also published a paper in [The Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.07626).
+
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ You can find the project documentation [here](https://alan-turing-institute.gith
 
 - The AutoEmulate project is run out of the [Alan Turing Institute](https://www.turing.ac.uk/).
 - Visit [autoemulate.com](https://www.autoemulate.com/) to learn more.
-- We have also published a paper in [The Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.07626).
+- We have also published a paper in [The Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.07626). 
+
+  Please cite this paper if you use the package in your work:
+
+  ```bibtex
+  @article{Stoffel2025, doi = {10.21105/joss.07626}, url = {https://doi.org/10.21105/joss.07626}, year = {2025}, publisher = {The Open Journal}, volume = {10}, number = {107}, pages = {7626}, author = {Martin A. Stoffel and Bryan M. Li and Kalle Westerling and Sophie Arana and Max Balmus and Eric Daub and Steve Niederer}, title = {AutoEmulate: A Python package for semi-automated emulation}, journal = {Journal of Open Source Software} }
+  ```
 
 ## Contributors
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -16,6 +16,8 @@ chapters:
   sections:
   - file: tutorials/01_start
   - file: tutorials/02_speed
+  - file: tutorials/03_emulation_sensitivity
+  - file: tutorials/04_active_learning
 
 - file: community/index
   sections:

--- a/docs/community/faq/faq-users.md
+++ b/docs/community/faq/faq-users.md
@@ -60,18 +60,14 @@
 
 ## Community and Learning Resources
 
-1. Are there any community projects or collaborations using `AutoEmulate` I can join or learn from?
-   <!-- Information on community-led projects, study groups, or collaborative research initiatives involving AutoEmulate. -->
-   - Reach out to Martin ([email](mailto:mstoffel@turing.ac.uk)) or Sophie ([email](mailto:sarana@turing.ac.uk)) for more information.
-
-2. Where can I find tutorials or case studies on using `AutoEmulate`?
+1. Where can I find tutorials or case studies on using `AutoEmulate`?
    <!-- Directions to comprehensive learning materials, such as video tutorials (if we want to record that), written guides, or published research papers using AutoEmulate. -->
    - See the [tutorial](../../tutorials/01_start.ipynb) for a comprehensive guide on using the package. Case studies are coming soon.
 
-3. How can I stay updated on new releases or updates to AutoEmulate?
+2. How can I stay updated on new releases or updates to AutoEmulate?
    <!-- Guidance on subscribing to newsletters when/if we will have that, community calls if we start that, following the project on social media if we want to create those platforms, or joining community forums/Slack once we have that ready... -->
    - Watch the [AutoEmulate repository](https://github.com/alan-turing-institute/autoemulate).
 
-4. What support options are available if I need help with AutoEmulate?
+3. What support options are available if I need help with AutoEmulate?
    <!-- Overview of support resources, including documentation, community forums/Slack when we have that ready... -->
-   - Please open an issue on GitHub or contact the maintainer ([email](mailto:mstoffel@turing.ac.uk)) directly.
+   - Please open an issue or start a discussion on [GitHub](https://github.com/alan-turing-institute/autoemulate).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,7 @@ version = "0.2.1dev1"
 description = "A python package for semi-automated emulation"
 license = "MIT"
 authors = [
-    "Martin Stoffel <mstoffel@turing.ac.uk>",
-    "Kalle Westerling <kwesterling@turing.ac.uk>",
-    "Bryan Li <bli@turing.ac.uk>",
-    "Max Balmus <mbalmus@turing.ac.uk>",
-    "Sophie Arana <sarana@turing.ac.uk>",
-    "Eric Daub <edaub@turing.ac.uk>",
-    "Steve Niederer <sniederer@turing.ac.uk>",
-    "Radka Jersakova <rjersakova@turing.ac.uk>",
-    "Edwin Brown <wbrown@turing.ac.uk>",
-    "Chris Sprague <csprague@turing.ac.uk>",
-    "Ed Chalstrey <echalstrey@turing.ac.uk>",
-    "Marjan Famili <mfamili@turing.ac.uk>",
-    "Paolo Conti <pconti@turing.ac.uk>",
-    "Sam Greenbury <sgreenbury@turing.ac.uk>",
+    "AutoEmulate contributors (see our GitHub page)"
 ]
 readme = "README.md"
 include = ["misc/AE_logo_final.png"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,13 @@ authors = [
     "Sophie Arana <sarana@turing.ac.uk>",
     "Eric Daub <edaub@turing.ac.uk>",
     "Steve Niederer <sniederer@turing.ac.uk>",
+    "Radka Jersakova <rjersakova@turing.ac.uk>",
+    "Edwin Brown <wbrown@turing.ac.uk>",
+    "Chris Sprague <csprague@turing.ac.uk>",
+    "Ed Chalstrey <echalstrey@turing.ac.uk>",
+    "Marjan Famili <mfamili@turing.ac.uk>",
+    "Paolo Conti <pconti@turing.ac.uk>",
+    "Sam Greenbury <sgreenbury@turing.ac.uk>",
 ]
 readme = "README.md"
 include = ["misc/AE_logo_final.png"]


### PR DESCRIPTION
### Changes

- Closes #359 (also added link to https://www.autoemulate.com/ navbar)
- Closes #354 and also adds `04_active_learning`
- Closes #353 
- Closes #385 
- Removed install and example code info from README as this is already on docs, to avoid duplication and drift

### TODO:
- [ ] Authors of tutorials 03 and 04 should check that the saved outputs are what we want shown on the docs site (test this locally with [jupyter](https://alan-turing-institute.github.io/autoemulate/community/contributing-docs.html#types-of-documentation-contributions)) @cisprague 