### PR TITLE
Fix tutorial rendering on docs page

### DIFF
--- a/docs/tutorials/07_AE_workflow.ipynb
+++ b/docs/tutorials/07_AE_workflow.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ! pip install git+https://github.com/alan-turing-institute/ModularCirc.git@dev"
+    "! pip install git+https://github.com/alan-turing-institute/ModularCirc.git@dev"
    ]
   },
   {

--- a/docs/tutorials/07_AE_workflow.ipynb
+++ b/docs/tutorials/07_AE_workflow.ipynb
@@ -18,7 +18,7 @@
     "- Sensitivity Analysis \n",
     "\n",
     "\n",
-    "<img src=\"../../misc/workflow.png\" alt=\"Work Flow\" style=\"width:100%;\"/>\n"
+    "<img src=\"https://raw.githubusercontent.com/alan-turing-institute/autoemulate/refs/heads/main/misc/workflow.png\" alt=\"Work Flow\" style=\"width:100%;\"/>\n"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "source": [
     "#### 3 - Wrapping your Simulator in AutoEmulate Simulator Base Class\n",
     "\n",
-    "<img src=\"../../misc/base_simulator_guid.png\" alt=\"Work Flow\" style=\"width:30%;\"/>\n"
+    "<img src=\"https://raw.githubusercontent.com/alan-turing-institute/autoemulate/refs/heads/main/misc/base_simulator_guid.png\" alt=\"Work Flow\" style=\"width:30%;\"/>\n"
    ]
   },
   {
@@ -371,7 +371,7 @@
    "source": [
     "\n",
     "\n",
-    "<img src=\"../../misc/vis_dashboard_pic_sample.png\" alt=\"Work Flow\" style=\"width:100%;\"/>"
+    "<img src=\"https://raw.githubusercontent.com/alan-turing-institute/autoemulate/refs/heads/main/misc/vis_dashboard_pic_sample.png\" alt=\"Work Flow\" style=\"width:100%;\"/>"
    ]
   },
   {


### PR DESCRIPTION
Fixing tutorial as it wasn't rendering well on the docs page:
- paths to images needed changing
- code didn't run because ModularCirc wasn't installed in the environment