### PR TITLE
400 revise input types

### DIFF
--- a/autoemulate/experimental/compare.py
+++ b/autoemulate/experimental/compare.py
@@ -73,7 +73,7 @@ class AutoEmulate(InputTypeMixin):
     def compare(
         self, n_iter: int = 10, cv: type[BaseCrossValidator] = KFold
     ) -> dict[str, dict[str, Any]]:
-        tuner = Tuner(self.train_val, y=None, n_iter=n_iter)
+        tuner = Tuner(self.train_val, n_iter=n_iter)
         models_evaluated = {}
         for model_cls in self.models:
             scores, configs = tuner.run(model_cls)

--- a/autoemulate/experimental/data/preprocessors.py
+++ b/autoemulate/experimental/data/preprocessors.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 import torch
-from autoemulate.experimental.types import InputLike
+from autoemulate.experimental.types import TensorLike
 
 
 class Preprocessor(ABC):
@@ -9,7 +9,7 @@ class Preprocessor(ABC):
     def __init__(*args, **kwargs): ...
 
     @abstractmethod
-    def preprocess(self, x: InputLike) -> InputLike: ...
+    def preprocess(self, x: TensorLike) -> TensorLike: ...
 
 
 class Standardizer(Preprocessor):

--- a/autoemulate/experimental/data/validation.py
+++ b/autoemulate/experimental/data/validation.py
@@ -2,7 +2,7 @@ import torch
 from autoemulate.experimental.types import InputLike, OutputLike, TensorLike
 
 
-class Base:
+class ValidationMixin:
     """
     Base class for active learning simulation and emulation.
 

--- a/autoemulate/experimental/data/validation.py
+++ b/autoemulate/experimental/data/validation.py
@@ -12,6 +12,10 @@ class Base:
     @staticmethod
     def _check(x: InputLike, y: InputLike | None):
         # TODO: compare with InputTypeMixin and consider additional implementation
+
+        # Convert to required types
+
+        # Check the types and shape are correct
         ...
 
     @staticmethod

--- a/autoemulate/experimental/emulators/base.py
+++ b/autoemulate/experimental/emulators/base.py
@@ -5,11 +5,11 @@ from torch import nn, optim
 
 from autoemulate.experimental.data.preprocessors import Preprocessor
 from autoemulate.experimental.data.utils import InputTypeMixin
-from autoemulate.experimental.data.validation import Base
+from autoemulate.experimental.data.validation import ValidationMixin
 from autoemulate.experimental.types import InputLike, OutputLike, TuneConfig
 
 
-class Emulator(ABC, Base):
+class Emulator(ABC, ValidationMixin):
     """
     The interface containing methods on emulators that are
     expected by downstream dependents. This includes:

--- a/autoemulate/experimental/emulators/base.py
+++ b/autoemulate/experimental/emulators/base.py
@@ -16,16 +16,12 @@ class Emulator(ABC, Base):
     - `AutoEmulate`
     """
 
-    # TODO: update emulators with these methods
-    # @abstractmethod
-    # def _fit(self, x: InputLike, y: InputLike | None): ...
-
-    # def fit(self, x: InputLike, y: InputLike | None):
-    #     self._check(x, y)
-    #     self._fit(x, y)
-
     @abstractmethod
-    def fit(self, x: InputLike, y: InputLike | None): ...
+    def _fit(self, x: InputLike, y: InputLike | None): ...
+
+    def fit(self, x: InputLike, y: InputLike | None):
+        self._check(x, y)
+        self._fit(x, y)
 
     @abstractmethod
     def __init__(
@@ -36,21 +32,15 @@ class Emulator(ABC, Base):
     def model_name(cls) -> str:
         return cls.__name__
 
-    # TODO: update emulators with these methods
-    # @abstractmethod
-    # def _predict(self, x: InputLike) -> OutputLike:
-    #     pass
-
-    # def predict(self, x: InputLike) -> OutputLike:
-    #     self._check(x, None)
-    #     output = self.predict(x)
-    #     # Check that it is Gaussian or Y
-    #     self._check_output(output)
-    #     return output
-
     @abstractmethod
-    def predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: InputLike) -> OutputLike:
         pass
+
+    def predict(self, x: InputLike) -> OutputLike:
+        self._check(x, None)
+        output = self._predict(x)
+        self._check_output(output)
+        return output
 
     @staticmethod
     @abstractmethod
@@ -115,7 +105,7 @@ class PyTorchBackend(nn.Module, Emulator, InputTypeMixin, Preprocessor):
         """
         return nn.MSELoss()(y_pred, y_true)
 
-    def fit(
+    def _fit(
         self,
         x: InputLike,
         y: InputLike | None,
@@ -170,14 +160,10 @@ class PyTorchBackend(nn.Module, Emulator, InputTypeMixin, Preprocessor):
             if self.verbose and (epoch + 1) % (self.epochs // 10 or 1) == 0:
                 print(f"Epoch [{epoch + 1}/{self.epochs}], Loss: {avg_epoch_loss:.4f}")
 
-    def predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: InputLike) -> OutputLike:
         self.eval()
         x = self.preprocess(x)
         return self(x)
-
-    def cross_validate(self, x: InputLike) -> None:
-        msg = "This function is not yet implemented."
-        raise NotImplementedError(msg)
 
     @staticmethod
     def get_tune_config():

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -153,7 +153,7 @@ class GaussianProcessExact(
         )
         logger.info(msg)
 
-    def fit(self, x: InputLike, y: InputLike | None):
+    def _fit(self, x: InputLike, y: InputLike | None):
         self.train()
         self.likelihood.train()
         # Ensure tensors and correct shapes
@@ -176,7 +176,7 @@ class GaussianProcessExact(
             self.log_epoch(epoch, loss)
             optimizer.step()
 
-    def predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: InputLike) -> OutputLike:
         self.eval()
         x = self.preprocess(x)
         x_tensor = self._convert_to_tensors(x)

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -5,9 +5,7 @@ import numpy as np
 import torch
 from gpytorch import ExactMarginalLogLikelihood
 from gpytorch.distributions import MultitaskMultivariateNormal, MultivariateNormal
-from gpytorch.kernels import (
-    ScaleKernel,
-)
+from gpytorch.kernels import ScaleKernel
 from gpytorch.likelihoods import MultitaskGaussianLikelihood
 from torch import nn
 
@@ -26,15 +24,12 @@ from autoemulate.emulators.gaussian_process import (
     zero_mean,
 )
 from autoemulate.experimental.data.preprocessors import Preprocessor, Standardizer
-from autoemulate.experimental.emulators.base import (
-    Emulator,
-    InputTypeMixin,
-)
+from autoemulate.experimental.emulators.base import Emulator, InputTypeMixin
 from autoemulate.experimental.emulators.gaussian_process import (
     CovarModuleFn,
     MeanModuleFn,
 )
-from autoemulate.experimental.types import InputLike, OutputLike
+from autoemulate.experimental.types import OutputLike, TensorLike
 from autoemulate.utils import set_random_seed
 
 
@@ -53,8 +48,8 @@ class GaussianProcessExact(
 
     def __init__(  # noqa: PLR0913 allow too many arguments since all currently required
         self,
-        x: InputLike,
-        y: InputLike,
+        x: TensorLike,
+        y: TensorLike,
         likelihood_cls: type[MultitaskGaussianLikelihood] = MultitaskGaussianLikelihood,
         mean_module_fn: MeanModuleFn = constant_mean,
         covar_module_fn: CovarModuleFn = rbf,
@@ -127,13 +122,13 @@ class GaussianProcessExact(
     def is_multioutput():
         return True
 
-    def preprocess(self, x: InputLike) -> InputLike:
+    def preprocess(self, x: TensorLike) -> TensorLike:
         """Preprocess the input data using the preprocessor."""
         if self.preprocessor is not None:
             x = self.preprocessor.preprocess(x)
         return x
 
-    def forward(self, x: InputLike):
+    def forward(self, x: TensorLike):
         assert isinstance(x, torch.Tensor)
         mean = self.mean_module(x)
 
@@ -153,7 +148,7 @@ class GaussianProcessExact(
         )
         logger.info(msg)
 
-    def _fit(self, x: InputLike, y: InputLike | None):
+    def _fit(self, x: TensorLike, y: TensorLike):
         self.train()
         self.likelihood.train()
         # Ensure tensors and correct shapes
@@ -176,7 +171,7 @@ class GaussianProcessExact(
             self.log_epoch(epoch, loss)
             optimizer.step()
 
-    def _predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: TensorLike) -> OutputLike:
         self.eval()
         x = self.preprocess(x)
         x_tensor = self._convert_to_tensors(x)

--- a/autoemulate/experimental/emulators/lightgbm.py
+++ b/autoemulate/experimental/emulators/lightgbm.py
@@ -73,20 +73,20 @@ class LightGBM(Emulator, InputTypeMixin):
             y (target): 1D array
         """
 
-        x, y = self._convert_to_numpy(x, y)
+        x_np, y_np = self._convert_to_numpy(x, y)
 
-        if y is None:
+        if y_np is None:
             msg = "y must be provided."
             raise ValueError(msg)
-        if y.ndim > 2:
-            msg = f"y must be 1D or 2D array. Found {y.ndim}D array."
+        if y_np.ndim > 2:
+            msg = f"y must be 1D or 2D array. Found {y_np.ndim}D array."
             raise ValueError(msg)
-        if y.ndim == 2:  # _convert_to_numpy may return 2D y
-            y = y.ravel()  # Ensure y is 1-dimensional
+        if y_np.ndim == 2:  # _convert_to_numpy may return 2D y
+            y_np = y_np.ravel()  # Ensure y is 1-dimensional
 
-        self.n_features_in_ = x.shape[1]
+        self.n_features_in_ = x_np.shape[1]
 
-        x, y = check_X_y(x, y, y_numeric=True)
+        x_np, y_np = check_X_y(x_np, y_np, y_numeric=True)
 
         self.model_ = LGBMRegressor(
             boosting_type=self.boosting_type,
@@ -110,7 +110,7 @@ class LightGBM(Emulator, InputTypeMixin):
             verbose=self.verbose,
         )
 
-        self.model_.fit(x, y)
+        self.model_.fit(x_np, y_np)
         self.is_fitted_ = True
 
     def _predict(self, x: TensorLike) -> OutputLike:

--- a/autoemulate/experimental/emulators/lightgbm.py
+++ b/autoemulate/experimental/emulators/lightgbm.py
@@ -3,11 +3,8 @@ from lightgbm import LGBMRegressor
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 from torch import Tensor
 
-from autoemulate.experimental.emulators.base import (
-    Emulator,
-    InputTypeMixin,
-)
-from autoemulate.experimental.types import InputLike, OutputLike
+from autoemulate.experimental.emulators.base import Emulator, InputTypeMixin
+from autoemulate.experimental.types import OutputLike, TensorLike
 
 
 class LightGBM(Emulator, InputTypeMixin):
@@ -20,8 +17,8 @@ class LightGBM(Emulator, InputTypeMixin):
 
     def __init__(  # noqa: PLR0913 allow too many arguments since all currently required
         self,
-        x: InputLike | None = None,
-        y: InputLike | None = None,
+        x: TensorLike | None = None,
+        y: TensorLike | None = None,
         boosting_type: str = "gbdt",
         num_leaves: int = 31,
         max_depth: int = -1,
@@ -68,7 +65,7 @@ class LightGBM(Emulator, InputTypeMixin):
     def is_multioutput() -> bool:
         return False
 
-    def _fit(self, x: InputLike, y: InputLike | None):
+    def _fit(self, x: TensorLike, y: TensorLike):
         """
         Fits the emulator to the data.
         The model expects the input data to be:
@@ -116,7 +113,7 @@ class LightGBM(Emulator, InputTypeMixin):
         self.model_.fit(x, y)
         self.is_fitted_ = True
 
-    def _predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: TensorLike) -> OutputLike:
         """Predicts the output of the emulator for a given input."""
         x = check_array(x)
         check_is_fitted(self, "is_fitted_")

--- a/autoemulate/experimental/emulators/lightgbm.py
+++ b/autoemulate/experimental/emulators/lightgbm.py
@@ -68,7 +68,7 @@ class LightGBM(Emulator, InputTypeMixin):
     def is_multioutput() -> bool:
         return False
 
-    def fit(self, x: InputLike, y: InputLike | None):
+    def _fit(self, x: InputLike, y: InputLike | None):
         """
         Fits the emulator to the data.
         The model expects the input data to be:
@@ -116,7 +116,7 @@ class LightGBM(Emulator, InputTypeMixin):
         self.model_.fit(x, y)
         self.is_fitted_ = True
 
-    def predict(self, x: InputLike) -> OutputLike:
+    def _predict(self, x: InputLike) -> OutputLike:
         """Predicts the output of the emulator for a given input."""
         x = check_array(x)
         check_is_fitted(self, "is_fitted_")

--- a/autoemulate/experimental/emulators/neural_processes/conditional_neural_process.py
+++ b/autoemulate/experimental/emulators/neural_processes/conditional_neural_process.py
@@ -347,7 +347,7 @@ class CNPModule(PyTorchBackend):
             reinterpreted_batch_ndims=1,
         )
 
-    def fit(
+    def _fit(
         self,
         x: InputLike,
         y: InputLike | None,
@@ -415,7 +415,7 @@ class CNPModule(PyTorchBackend):
             if self.verbose and (epoch + 1) % (self.epochs // 10 or 1) == 0:
                 print(f"Epoch [{epoch + 1}/{self.epochs}], Loss: {avg_epoch_loss:.4f}")
 
-    def predict(self, x: InputLike) -> DistributionLike:
+    def _predict(self, x: InputLike) -> DistributionLike:
         """
         Predict uses the training data as the context data and the input x as the target
         data. The data is preprocessed within the method.

--- a/autoemulate/experimental/emulators/neural_processes/conditional_neural_process.py
+++ b/autoemulate/experimental/emulators/neural_processes/conditional_neural_process.py
@@ -3,7 +3,7 @@ import torch
 import torch.utils
 import torch.utils.data
 from autoemulate.experimental.emulators.base import PyTorchBackend
-from autoemulate.experimental.types import DistributionLike, InputLike, TensorLike
+from autoemulate.experimental.types import DistributionLike, TensorLike
 from torch import nn
 from torch.utils.data import Dataset
 
@@ -246,8 +246,8 @@ class CNPModule(PyTorchBackend):
 
     def __init__(  # noqa: PLR0913
         self,
-        x: InputLike,
-        y: InputLike,
+        x: TensorLike,
+        y: TensorLike,
         hidden_dim: int = 32,
         latent_dim: int = 16,
         hidden_layers_enc: int = 2,
@@ -349,8 +349,8 @@ class CNPModule(PyTorchBackend):
 
     def _fit(
         self,
-        x: InputLike,
-        y: InputLike | None,
+        x: TensorLike,
+        y: TensorLike,
     ):
         """
         Fit the model to the data.
@@ -415,7 +415,7 @@ class CNPModule(PyTorchBackend):
             if self.verbose and (epoch + 1) % (self.epochs // 10 or 1) == 0:
                 print(f"Epoch [{epoch + 1}/{self.epochs}], Loss: {avg_epoch_loss:.4f}")
 
-    def _predict(self, x: InputLike) -> DistributionLike:
+    def _predict(self, x: TensorLike) -> DistributionLike:
         """
         Predict uses the training data as the context data and the input x as the target
         data. The data is preprocessed within the method.

--- a/autoemulate/experimental/learners/base.py
+++ b/autoemulate/experimental/learners/base.py
@@ -7,14 +7,14 @@ from anytree import Node, RenderTree
 from torch.distributions import MultivariateNormal
 from torcheval.metrics import MeanSquaredError, R2Score
 
-from autoemulate.experimental.data.validation import Base
+from autoemulate.experimental.data.validation import ValidationMixin
 from autoemulate.experimental.emulators.base import Emulator
 
 from ..types import GaussianLike, TensorLike
 
 
 @dataclass(kw_only=True)
-class Simulator(Base, ABC):
+class Simulator(ValidationMixin, ABC):
     """
     Simulator abstract class for generating outputs from inputs.
 
@@ -78,7 +78,7 @@ class Simulator(Base, ABC):
 
 
 @dataclass(kw_only=True)
-class Learner(Base, ABC):
+class Learner(ValidationMixin, ABC):
     """
     Learner class that combines a simulator and an emulator for active learning.
 

--- a/tests/experimental/test_experimental_base.py
+++ b/tests/experimental/test_experimental_base.py
@@ -7,17 +7,6 @@ from autoemulate.experimental.tuner import Tuner
 from torch import nn, optim
 from torch.utils.data import DataLoader, TensorDataset
 
-# @pytest.fixture
-# def model_config() -> M:
-#     return {
-#         "epochs": 10,
-#         "batch_size": 2,
-#         "shuffle": False,
-#         "verbose": False,
-#         "optimizer": torch.optim.Adam,
-#         "criterion": torch.nn.MSELoss,
-#     }
-
 
 class TestInputTypeMixin:
     """

--- a/tests/experimental/test_experimental_base.py
+++ b/tests/experimental/test_experimental_base.py
@@ -122,8 +122,8 @@ class TestPyTorchBackend:
         """
         Test the fit method of PyTorchBackend.
         """
-        x = np.array([[1.0], [2.0], [3.0]])
-        y = np.array([[2.0], [4.0], [6.0]])
+        x = torch.Tensor(np.array([[1.0], [2.0], [3.0]]))
+        y = torch.Tensor(np.array([[2.0], [4.0], [6.0]]))
         self.model.fit(x, y)
 
         assert isinstance(self.model.loss_history, list)
@@ -134,8 +134,8 @@ class TestPyTorchBackend:
         """
         Test the predict method of PyTorchBackend.
         """
-        x_train = np.array([[1.0], [2.0], [3.0]])
-        y_train = np.array([[2.0], [4.0], [6.0]])
+        x_train = torch.Tensor(np.array([[1.0], [2.0], [3.0]]))
+        y_train = torch.Tensor(np.array([[2.0], [4.0], [6.0]]))
         self.model.fit(x_train, y_train)
 
         X_test = torch.tensor([[4.0]])

--- a/tests/experimental/test_experimental_base.py
+++ b/tests/experimental/test_experimental_base.py
@@ -145,15 +145,6 @@ class TestPyTorchBackend:
         assert y_pred.shape == (1, 1)
         assert y_pred.shape == (1, 1)
 
-    def test_tune_xy(self):
-        """
-        Test that Tuner accepts X,Y inputs.
-        """
-        x_train = torch.Tensor(np.arange(16).reshape(-1, 1))
-        y_train = 2 * x_train
-        tuner = Tuner(x_train, y_train, n_iter=10)
-        tuner.run(self.DummyModel)
-
     def test_standardizer(self):
         x_train = torch.Tensor(
             [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0], [5.0, 5.0]]
@@ -179,5 +170,5 @@ class TestPyTorchBackend:
         x_train = torch.Tensor(np.arange(16).reshape(-1, 1))
         y_train = 2 * x_train
         dataset = self.model._convert_to_dataset(x_train, y_train)
-        tuner = Tuner(x=dataset, y=None, n_iter=10)
+        tuner = Tuner(x=dataset, n_iter=10)
         tuner.run(self.DummyModel)

--- a/tests/experimental/test_experimental_conditional_neural_process.py
+++ b/tests/experimental/test_experimental_conditional_neural_process.py
@@ -66,7 +66,7 @@ def test_cnp_module_predict_fails_with_calling_fit_first(sample_data_y1d):
 
 def test_tune_gp(sample_data_y1d):
     x, y = sample_data_y1d
-    tuner = Tuner(x, y, n_iter=20)
+    tuner = Tuner(x, n_iter=20)
     scores, configs = tuner.run(CNPModule)
     assert len(scores) == 20
     assert len(configs) == 20

--- a/tests/experimental/test_experimental_conditional_neural_process.py
+++ b/tests/experimental/test_experimental_conditional_neural_process.py
@@ -4,6 +4,7 @@ from autoemulate.experimental.emulators.neural_processes.conditional_neural_proc
 )
 from autoemulate.experimental.tuner import Tuner
 from autoemulate.experimental.types import DistributionLike
+from torch.utils.data import TensorDataset
 
 
 def test_cnp_module_fit_and_predict(sample_data_y1d, new_data_y1d):
@@ -66,7 +67,8 @@ def test_cnp_module_predict_fails_with_calling_fit_first(sample_data_y1d):
 
 def test_tune_gp(sample_data_y1d):
     x, y = sample_data_y1d
-    tuner = Tuner(x, n_iter=20)
+    dataset = TensorDataset(x, y)
+    tuner = Tuner(dataset, n_iter=20)
     scores, configs = tuner.run(CNPModule)
     assert len(scores) == 20
     assert len(configs) == 20

--- a/tests/experimental/test_experimental_gaussian_process_exact.py
+++ b/tests/experimental/test_experimental_gaussian_process_exact.py
@@ -42,7 +42,8 @@ def test_multioutput_gp(sample_data_y2d, new_data_y2d):
 
 def test_tune_gp(sample_data_y1d):
     x, y = sample_data_y1d
-    tuner = Tuner(x, y, n_iter=5)
+    # TODO: move x and y into a Dataset(x, y)
+    tuner = Tuner(x, n_iter=5)
     scores, configs = tuner.run(GaussianProcessExact)
     assert len(scores) == 5
     assert len(configs) == 5

--- a/tests/experimental/test_experimental_gaussian_process_exact.py
+++ b/tests/experimental/test_experimental_gaussian_process_exact.py
@@ -5,6 +5,7 @@ from autoemulate.experimental.emulators.gaussian_process.exact import (
 )
 from autoemulate.experimental.tuner import Tuner
 from autoemulate.experimental.types import DistributionLike
+from torch.utils.data import TensorDataset
 
 
 def test_predict_with_uncertainty_gp(sample_data_y1d, new_data_y1d):
@@ -42,8 +43,8 @@ def test_multioutput_gp(sample_data_y2d, new_data_y2d):
 
 def test_tune_gp(sample_data_y1d):
     x, y = sample_data_y1d
-    # TODO: move x and y into a Dataset(x, y)
-    tuner = Tuner(x, n_iter=5)
+    dataset = TensorDataset(x, y)
+    tuner = Tuner(dataset, n_iter=5)
     scores, configs = tuner.run(GaussianProcessExact)
     assert len(scores) == 5
     assert len(configs) == 5

--- a/tests/experimental/test_experimental_lightgbm.py
+++ b/tests/experimental/test_experimental_lightgbm.py
@@ -1,6 +1,4 @@
-from autoemulate.experimental.emulators.lightgbm import (
-    LightGBM,
-)
+from autoemulate.experimental.emulators.lightgbm import LightGBM
 from autoemulate.experimental.tuner import Tuner
 from autoemulate.experimental.types import TensorLike
 
@@ -16,7 +14,7 @@ def test_predict_lightgbm(sample_data_y1d, new_data_y1d):
 
 def test_tune_lightgbm(sample_data_y1d):
     x, y = sample_data_y1d
-    tuner = Tuner(x, y, n_iter=5)
+    tuner = Tuner(x, n_iter=5)
     scores, configs = tuner.run(LightGBM)
     assert len(scores) == 5
     assert len(configs) == 5

--- a/tests/experimental/test_experimental_lightgbm.py
+++ b/tests/experimental/test_experimental_lightgbm.py
@@ -1,6 +1,7 @@
 from autoemulate.experimental.emulators.lightgbm import LightGBM
 from autoemulate.experimental.tuner import Tuner
 from autoemulate.experimental.types import TensorLike
+from torch.utils.data import TensorDataset
 
 
 def test_predict_lightgbm(sample_data_y1d, new_data_y1d):
@@ -14,7 +15,8 @@ def test_predict_lightgbm(sample_data_y1d, new_data_y1d):
 
 def test_tune_lightgbm(sample_data_y1d):
     x, y = sample_data_y1d
-    tuner = Tuner(x, n_iter=5)
+    dataset = TensorDataset(x, y)
+    tuner = Tuner(dataset, n_iter=5)
     scores, configs = tuner.run(LightGBM)
     assert len(scores) == 5
     assert len(configs) == 5

--- a/tests/experimental/test_experimental_model_selection.py
+++ b/tests/experimental/test_experimental_model_selection.py
@@ -15,10 +15,10 @@ def test_cross_validate():
         def __init__(self, x=None, y=None, **kwargs):
             pass
 
-        def fit(self, x, y):
+        def _fit(self, x, y):
             pass
 
-        def predict(self, x):
+        def _predict(self, x):
             return torch.tensor([val * 2 for val in x])
 
         @staticmethod


### PR DESCRIPTION
All input types in the emulator methods are changed from InputLike to TensorLike. 

After some discussion with @sgreenbury - We have decided to keep other input types as InputLike for other modules such as model_selection.py and validation.py