### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autoemulate"
-version = "0.3.1"
+version = "0.3.2"
 description = "A python package for semi-automated emulation"
 license = "MIT"
 authors = ["AutoEmulate contributors (see our GitHub page)"]


### PR DESCRIPTION
Closes #508 

The main motivation for the version is a bug in the HM implementation that has now been fixes (#507). Additionally, the HistoryMatchingDashboard plots no longer get duplicated.