### PR TITLE
Add epidemic and projectile Simulator 

### DIFF
--- a/autoemulate/simulations/epidemic.py
+++ b/autoemulate/simulations/epidemic.py
@@ -1,6 +1,35 @@
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from autoemulate.simulations.base import Simulator
+
+
+class EpidemicSimulator(Simulator):
+    """
+    Simulator of infectious disease spread (SIR).
+    """
+
+    def __init__(self, param_ranges={"beta": (0.1, 0.5), "gamma": (0.01, 0.2)}):
+        super().__init__(param_ranges)
+        self._output_names = ["distance"]
+
+    def sample_forward(self, params: dict[str, float]) -> np.ndarray:
+        """
+        Parameters
+        ----------
+        params : dict[str, float]
+            Dictionary of input parameter values to simulate:
+            - `beta`: the transimission rate per day
+            - `gamma`: the recovery rate per day
+
+        Returns
+        -------
+        infection : float
+            Peak infection rate.
+        """
+        x = np.array([params["beta"], params["gamma"]])
+        return simulate_epidemic(x)
+
 
 def simulate_epidemic(x, N=1000, I0=1):
     """Simulate an epidemic using the SIR model.

--- a/autoemulate/simulations/projectile.py
+++ b/autoemulate/simulations/projectile.py
@@ -2,6 +2,8 @@
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from autoemulate.simulations.base import Simulator
+
 # Create our simulator, which solves a nonlinear differential equation describing projectile
 # motion with drag. A projectile is launched from an initial height of 2 meters at an
 # angle of 45 degrees and falls under the influence of gravity and air resistance.
@@ -9,6 +11,28 @@ from scipy.integrate import solve_ivp
 # travelled by the projectile as a function of the drag coefficient and the launch velocity.
 
 # define functions needed for simulator
+
+
+class ProjectileSimulator(Simulator):
+    def __init__(self, param_ranges={"c": [-5.0, 1.0], "v0": [0.0, 1000]}):
+        super().__init__(param_ranges)
+        self._output_names = ["distance"]
+
+    def sample_forward(self, params: dict[str, float]) -> np.ndarray:
+        """
+        Parameters
+        ----------
+        params : dict[str, float]
+            Dictionary of input parameter values
+            to simulate (c, v0).
+
+        Returns
+        -------
+        distance : float
+            Distance travelled by projectile.
+        """
+        x = np.array([params["c"], params["v0"]])
+        return simulate_projectile(x)
 
 
 def f(t, y, c):

--- a/autoemulate/simulations/projectile.py
+++ b/autoemulate/simulations/projectile.py
@@ -14,7 +14,11 @@ from autoemulate.simulations.base import Simulator
 
 
 class ProjectileSimulator(Simulator):
-    def __init__(self, param_ranges={"c": [-5.0, 1.0], "v0": [0.0, 1000]}):
+    """
+    Simulator of projectile motion.
+    """
+
+    def __init__(self, param_ranges={"c": (-5.0, 1.0), "v0": (0.0, 1000)}):
         super().__init__(param_ranges)
         self._output_names = ["distance"]
 
@@ -23,8 +27,9 @@ class ProjectileSimulator(Simulator):
         Parameters
         ----------
         params : dict[str, float]
-            Dictionary of input parameter values
-            to simulate (c, v0).
+            Dictionary of input parameter values to simulate:
+            - `c`: the drag coefficient on a log scale
+            - `v0`: velocity
 
         Returns
         -------


### PR DESCRIPTION
Adds a `Simulator` for the epidemic and projectile simulations.

Both can now be used in the same way as the NaghaviSimulator:
```python
#sim = ProjectileSimulator
sim = EpidemicSimulator() 
X = sim.sample_inputs(200)
y = sim.run_batch_simulations(X)
```