### PR TITLE
Update simulators to return arrays of right shape

### DIFF
--- a/autoemulate/simulations/epidemic.py
+++ b/autoemulate/simulations/epidemic.py
@@ -24,11 +24,12 @@ class EpidemicSimulator(Simulator):
 
         Returns
         -------
-        infection : float
+        infection : np.ndarray
             Peak infection rate.
         """
         x = np.array([params["beta"], params["gamma"]])
-        return simulate_epidemic(x)
+        y = simulate_epidemic(x)
+        return np.array([y])
 
 
 def simulate_epidemic(x, N=1000, I0=1):

--- a/autoemulate/simulations/projectile.py
+++ b/autoemulate/simulations/projectile.py
@@ -33,11 +33,12 @@ class ProjectileSimulator(Simulator):
 
         Returns
         -------
-        distance : float
+        distance : np.ndarray
             Distance travelled by projectile.
         """
         x = np.array([params["c"], params["v0"]])
-        return simulate_projectile(x)
+        y = simulate_projectile(x)
+        return np.array([y])
 
 
 def f(t, y, c):

--- a/tests/test_base_simulator.py
+++ b/tests/test_base_simulator.py
@@ -182,16 +182,20 @@ def test_projectile_simulator():
     sim = ProjectileSimulator()
     X = sim.sample_inputs(100)
     y = sim.run_batch_simulations(X)
+    assert y.shape == (100, 1)
+
     y_old = np.array([simulate_projectile(x) for x in X])
-    assert np.allclose(y, y_old)
+    assert np.allclose(y, y_old.reshape(-1, 1))
 
 
-def test_epidemoc_simulator():
+def test_epidemic_simulator():
     """
     Sense check EpidemicSimulator against previous implementation.
     """
     sim = EpidemicSimulator()
     X = sim.sample_inputs(100)
     y = sim.run_batch_simulations(X)
+    assert y.shape == (100, 1)
+
     y_old = np.array([simulate_epidemic(x) for x in X])
-    assert np.allclose(y, y_old)
+    assert np.allclose(y, y_old.reshape(-1, 1))


### PR DESCRIPTION
Updates projectile and epidemic simulators to return numpy arrays instead of floats as expected. The tests have been updated to check that `sim.run_batch_simulations(X)` for both returns the right shape `(n_samples, 1)`.