### PR TITLE
Update quickstart tutorial

### DIFF
--- a/docs/getting-started/quickstart.ipynb
+++ b/docs/getting-started/quickstart.ipynb
@@ -1723,26 +1723,6 @@
    "source": [
     "gp_final.predict(X[:10])"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Saving / loading models\n",
-    "\n",
-    "Lastly, we can save and load an emulator. To load, we need an initialised `AutoEmulate` object. This will ensure that the environment in which the model was saved is similar to the environment in which it is loaded."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# # save & load best emulator\n",
-    "# ae.save(gp_final, \"gp_final\")\n",
-    "# emulator = ae.load(\"gp_final\")"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
In the quickstart tutorial we get the following error when trying to load a saved GPytorch model. 

```
autoemulate - Failed to load model from gp_final: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL gpytorch.likelihoods.multitask_gaussian_likelihood.MultitaskGaussianLikelihood was not an allowed global by default. Please use `torch.serialization.add_safe_globals([MultitaskGaussianLikelihood])` or the `torch.serialization.safe_globals([MultitaskGaussianLikelihood])` context manager to allowlist this global if you trust this class/function.
```

We should fix this in the refactor but for the purposes of today, I am removing this section from the quickstart tutorial. We could also deprecate the torch version but that feels suboptimal.