### PR TITLE
Post-workshop improved tutorial setup instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,7 +59,11 @@ Then activate the virtual environment using the command displayed by the previou
 
 You can run the Quickstart demo and other interactive tutorials fron the documentation locally.
 The examples are all Jupyter notebooks and can be run in your favoured method, such as JupyterLab, Jupyter Notebook, or VS Code.
+
+<details>
+<summary>
 These steps will guide you in the simplest way to set up a virtual environment, install the package from PyPI and run the notebooks with JupyterLab.
+</summary>
 
 1. Clone the AutoEmulate repository:
 
@@ -113,3 +117,5 @@ These steps will guide you in the simplest way to set up a virtual environment, 
 9. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab.
 10. Set the kernel to use the `Python (autoemulate)` kernel you created earlier. You can do this by clicking on the kernel name in the top right corner of the JupyterLab interface and selecting `Python (autoemulate)` from the dropdown menu.
 11. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.
+
+</details>

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -110,5 +110,6 @@ These steps will guide you in the simplest way to set up a virtual environment, 
    ```bash
    jupyter lab
    ```
-8. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab to start exploring `AutoEmulate`.
-9. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.
+8. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab.
+9. Set the kernel to use the `autoemulate` virtual environment you created (it should be automatically detected).
+10. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -105,11 +105,18 @@ These steps will guide you in the simplest way to set up a virtual environment, 
    ```bash
    pip install jupyterlab
    ```
-7. Launch JupyterLab:
+7. Create a Jupyter kernel for the virtual environment:
+
+   ```bash
+   python -m ipykernel install --user --name autoemulate --display-name "Python (autoemulate)"
+   ```
+
+   This command registers the virtual environment as a Jupyter kernel named `Python (autoemulate)`, which you can select in JupyterLab.
+8. Launch JupyterLab:
 
    ```bash
    jupyter lab
    ```
-8. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab.
-9. Set the kernel to use the `autoemulate` virtual environment you created (it should be automatically detected).
-10. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.
+9. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab.
+10. Set the kernel to use the `Python (autoemulate)` kernel you created earlier. You can do this by clicking on the kernel name in the top right corner of the JupyterLab interface and selecting `Python (autoemulate)` from the dropdown menu.
+11. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -52,7 +52,7 @@ poetry env activate
 Then activate the virtual environment using the command displayed by the previous command. This will be something like:
 
 ```bash
-    source /Users/yourName/Library/Caches/pypoetry/virtualenvs/autoemulate-l4vGdsmY-py3.11/bin/activate
+source /Users/yourName/Library/Caches/pypoetry/virtualenvs/autoemulate-l4vGdsmY-py3.11/bin/activate
 ```
 
 ## Interactive tutorials

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,20 +1,13 @@
 # Installation instructions
 
-`AutoEmulate` is a Python package that can be installed in a number of ways. In this section we will describe the main ways to install the package.
+`AutoEmulate` is a Python package that can be installed in a number of ways.
+In this section we will describe the main ways to install the package.
+For new users, we recommend installing the package from PyPI.
+For users who want to contribute to the package, we recommend using Poetry to install the package from the source code.
 
 ## Prerequisites
 
 **Python Version:** `AutoEmulate` requires Python `>=3.10` and `<3.13`.
-
-## Install from GitHub
-
-This is the easiest way to install `AutoEmulate`.
-
-Currently, because we are in active development, it's recommended to install the development version from GitHub:
-
-```bash
-pip install git+https://github.com/alan-turing-institute/autoemulate.git
-```
 
 ## Install from PyPI
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,3 +61,54 @@ Then activate the virtual environment using the command displayed by the previou
 ```bash
     source /Users/yourName/Library/Caches/pypoetry/virtualenvs/autoemulate-l4vGdsmY-py3.11/bin/activate
 ```
+
+## Interactive tutorials
+
+You can run the Quickstart demo and other interactive tutorials fron the documentation locally.
+The examples are all Jupyter notebooks and can be run in your favoured method, such as JupyterLab, Jupyter Notebook, or VS Code.
+These steps will guide you in the simplest way to set up a virtual environment, install the package from PyPI and run the notebooks with JupyterLab.
+
+1. Clone the AutoEmulate repository:
+
+   ```bash
+   git clone https://github.com/alan-turing-institute/autoemulate
+   ```
+2. Navigate into the directory:
+
+   ```bash
+   cd autoemulate
+   ```
+3. Set up a virtual environment called `autoemulate`:
+
+   ```bash
+   python -m venv autoemulate
+   ```
+4. Activate the virtual environment:
+   - On Windows:
+
+     ```bash
+     autoemulate\Scripts\activate
+     ```
+
+   - On macOS/Linux:
+
+     ```bash
+     source autoemulate/bin/activate
+     ```
+5. Install the package from PyPI:
+
+   ```bash
+   pip install autoemulate
+   ```
+6. Install JupyterLab:
+
+   ```bash
+   pip install jupyterlab
+   ```
+7. Launch JupyterLab:
+
+   ```bash
+   jupyter lab
+   ```
+8. Open the `docs/getting-started/quickstart.ipynb` notebook in JupyterLab to start exploring `AutoEmulate`.
+9. Find other interactive tutorials in the `docs/tutorials` directory, which you can open and run in JupyterLab.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,3 +1,5 @@
 # Tutorials
 
 These are more in-depth workflows which cover all aspects of `AutoEmulate`, from comprehensive overviews of the features to strategies for minimising computation time with larger datasets or when using hyperparameter optimisation.
+
+These tutorials are all Jupyter notebooks which can be [run in a local interactive session](../getting-started/installation.md#interactive-tutorials).


### PR DESCRIPTION
Closes #527 

### Changes

1. Added expandable instructions for quick setup of running notebooks locally
2. Prioritised PyPI installation at the top since we are now doing releases.
3. Removed the suggestion to install with pip from GitHub. I think developers/contibuters should install with Poetry, everyone else should install directly from pip