### PR TITLE
Execute nb when building docs except workflow example

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,9 @@ theme:
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: 'off'
+  execute_notebooks: 'force'
+  exclude_patterns:
+    - "07_AE_workflow.ipynb"
   exclude_tags:
     - skip-execution
 


### PR DESCRIPTION
Closes #538 

The reason we turned execution off was because the workflow example was getting interrupted. This should just skip the workflow execution but run everything else. It feels we should merge this before merging #554 