### PR TITLE
Add torch default dtype constant

### DIFF
--- a/autoemulate/experimental/data/utils.py
+++ b/autoemulate/experimental/data/utils.py
@@ -6,6 +6,7 @@ from autoemulate.experimental.types import (
     InputLike,
     OutputLike,
     TensorLike,
+    TorchDefaultDType,
     TorchScalarDType,
 )
 from sklearn.utils.validation import check_X_y
@@ -28,9 +29,9 @@ class ConversionMixin:
         """
         # Convert input to Dataset if not already
         if isinstance(x, np.ndarray):
-            x = torch.tensor(x, dtype=torch.float32)
+            x = torch.tensor(x, dtype=TorchDefaultDType)
         if isinstance(y, np.ndarray):
-            y = torch.tensor(y, dtype=torch.float32)
+            y = torch.tensor(y, dtype=TorchDefaultDType)
 
         if isinstance(x, torch.Tensor | np.ndarray) and isinstance(
             y, torch.Tensor | np.ndarray
@@ -77,7 +78,7 @@ class ConversionMixin:
         cls,
         x: InputLike,
         y: InputLike | None = None,
-        dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype = TorchDefaultDType,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """
         Convert InputLike x, y to Tensor or tuple of Tensors.

--- a/autoemulate/experimental/emulators/polynomials.py
+++ b/autoemulate/experimental/emulators/polynomials.py
@@ -52,7 +52,7 @@ class PolynomialRegression(PyTorchBackend):
         # Transform input using the fitted PolynomialFeatures
         x_np, _ = self._convert_to_numpy(x)
         x_poly = self.poly.transform(x_np)
-        x_poly_tensor = torch.tensor(x_poly, dtype=torch.float32, device=self.device)
+        x_poly_tensor = torch.tensor(x_poly, dtype=x.dtype, device=self.device)
         return self.linear(x_poly_tensor)
 
     @staticmethod

--- a/autoemulate/experimental/learners/base.py
+++ b/autoemulate/experimental/learners/base.py
@@ -12,7 +12,7 @@ from autoemulate.experimental.emulators.base import Emulator
 from autoemulate.experimental.logging_config import get_configured_logger
 from autoemulate.experimental.simulations.base import Simulator
 
-from ..types import GaussianLike, TensorLike
+from ..types import GaussianLike, TensorLike, TorchDefaultDType
 
 
 @dataclass(kw_only=True)
@@ -42,6 +42,7 @@ class Learner(ValidationMixin, ABC):
     log_level: str = "progress_bar"
     in_dim: int = field(init=False)
     out_dim: int = field(init=False)
+    dtype: torch.dtype = field(default=TorchDefaultDType)
 
     def __post_init__(self):
         """
@@ -215,8 +216,8 @@ class Active(Learner):
                   cumulative number of queries.
         """
         # pull histories into float tensors
-        mse = torch.tensor(self.metrics["mse"], dtype=torch.float32)
-        q = torch.tensor(self.metrics["n_queries"], dtype=torch.float32)
+        mse = torch.tensor(self.metrics["mse"], dtype=self.dtype)
+        q = torch.tensor(self.metrics["n_queries"], dtype=self.dtype)
 
         # build per-query ratios safely (avoid zero division)
         d = {}

--- a/autoemulate/experimental/simulations/base.py
+++ b/autoemulate/experimental/simulations/base.py
@@ -148,7 +148,8 @@ class Simulator(ABC, ValidationMixin):
         if isinstance(y, TensorLike):
             y = self.check_matrix(y)
             x, y = self.check_pair(x, y)
-            return y
+            # Currently assume that the output is the same dtype as input
+            return y.to(dtype=x.dtype)
         return None
 
     def forward_batch(self, x: TensorLike) -> TensorLike:

--- a/autoemulate/experimental/simulations/base.py
+++ b/autoemulate/experimental/simulations/base.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from autoemulate.experimental.data.utils import ValidationMixin, set_random_seed
 from autoemulate.experimental.logging_config import get_configured_logger
 from autoemulate.experimental.simulations.experimental_design import LatinHypercube
-from autoemulate.experimental.types import TensorLike
+from autoemulate.experimental.types import TensorLike, TorchDefaultDType
 
 logger = logging.getLogger("autoemulate")
 
@@ -85,7 +85,10 @@ class Simulator(ABC, ValidationMixin):
         return self._out_dim
 
     def sample_inputs(
-        self, n_samples: int, random_seed: int | None = None
+        self,
+        n_samples: int,
+        random_seed: int | None = None,
+        dtype: torch.dtype = TorchDefaultDType,
     ) -> TensorLike:
         """
         Generate random samples using Latin Hypercube Sampling.
@@ -106,7 +109,7 @@ class Simulator(ABC, ValidationMixin):
         if random_seed is not None:
             set_random_seed(random_seed)  # type: ignore PGH003
         lhd = LatinHypercube(self.param_bounds)
-        return lhd.sample(n_samples)
+        return lhd.sample(n_samples, dtype=dtype)
 
     @abstractmethod
     def _forward(self, x: TensorLike) -> TensorLike | None:

--- a/autoemulate/experimental/simulations/epidemic.py
+++ b/autoemulate/experimental/simulations/epidemic.py
@@ -3,7 +3,7 @@ import torch
 from scipy.integrate import solve_ivp
 
 from autoemulate.experimental.simulations.base import Simulator
-from autoemulate.experimental.types import NumpyLike, TensorLike
+from autoemulate.experimental.types import NumpyLike, TensorLike, TorchDefaultDType
 
 
 class Epidemic(Simulator):
@@ -41,8 +41,7 @@ class Epidemic(Simulator):
             f"Simulator._forward expects a single input, got {x.shape[0]}"
         )
         y = simulate_epidemic(x.cpu().numpy()[0])
-        # TODO (#537): update with default dtype
-        return torch.tensor([y], dtype=torch.float32).view(-1, 1)
+        return torch.tensor([y], dtype=TorchDefaultDType).view(-1, 1)
 
 
 def simulate_epidemic(x: NumpyLike, N: int = 1000, I0: int = 1) -> float:

--- a/autoemulate/experimental/simulations/experimental_design.py
+++ b/autoemulate/experimental/simulations/experimental_design.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 import mogp_emulator
 import torch
 
-from autoemulate.experimental.types import TensorLike
+from autoemulate.experimental.types import TensorLike, TorchDefaultDType
 
 
 class ExperimentalDesign(ABC):
@@ -63,9 +63,9 @@ class LatinHypercube(ExperimentalDesign):
         """Initializes a LatinHypercube object."""
         self.sampler = mogp_emulator.LatinHypercubeDesign(bounds_list)
 
-    def sample(self, n: int) -> TensorLike:
+    def sample(self, n: int, dtype=TorchDefaultDType) -> TensorLike:
         sample_array = self.sampler.sample(n)
-        return torch.tensor(sample_array, dtype=torch.float32)
+        return torch.tensor(sample_array, dtype=dtype)
 
     def get_n_parameters(self) -> int:
         return self.sampler.get_n_parameters()

--- a/autoemulate/experimental/types.py
+++ b/autoemulate/experimental/types.py
@@ -20,4 +20,12 @@ ModelConfig: TypeAlias = dict[str, ParamLike]
 DeviceLike: TypeAlias = str | torch.device
 
 # Torch dtype's
-TorchScalarDType = (torch.float32, torch.float64, torch.int32, torch.int64)
+TorchScalarDType: tuple[torch.dtype, ...] = (
+    torch.float32,
+    torch.float64,
+    torch.int32,
+    torch.int64,
+)
+
+# Default torch dtype (float32)
+TorchDefaultDType: torch.dtype = torch.float32

--- a/docs/experimental/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/experimental/tutorials/emulation/01_quickstart.ipynb
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -69,8 +69,8 @@
     "\n",
     "projectile = Projectile()\n",
     "n_samples = 500\n",
-    "x = projectile.sample_inputs(n_samples).float()\n",
-    "y = projectile.forward_batch(x).float()\n",
+    "x = projectile.sample_inputs(n_samples)\n",
+    "y = projectile.forward_batch(x)\n",
     "\n",
     "x.shape, y.shape"
    ]
@@ -685,7 +685,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "autoemulate-l4vGdsmY-py3.11",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -699,7 +699,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/tests/experimental/conftest.py
+++ b/tests/experimental/conftest.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import torch
+from autoemulate.experimental.types import TorchDefaultDType
 from sklearn.datasets import make_regression
 
 N_S = 20
@@ -115,7 +116,7 @@ def noisy_data():
     Generate a highly noisy dataset to test stochasticity effects.
     """
     rng = np.random.RandomState(0)
-    x = torch.tensor(rng.normal(size=(100, 2)), dtype=torch.float32)
-    y = torch.tensor(rng.normal(size=(100,)), dtype=torch.float32)
+    x = torch.tensor(rng.normal(size=(100, 2)), dtype=TorchDefaultDType)
+    y = torch.tensor(rng.normal(size=(100,)), dtype=TorchDefaultDType)
     x2 = x[:4].clone()
     return x, y, x2

--- a/tests/experimental/test_experimental_base_simulator.py
+++ b/tests/experimental/test_experimental_base_simulator.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from autoemulate.experimental.simulations.base import Simulator
-from autoemulate.experimental.types import TensorLike
+from autoemulate.experimental.types import TensorLike, TorchDefaultDType
 from torch import Tensor
 
 
@@ -9,9 +9,7 @@ class MockSimulator(Simulator):
     """Mock implementation of Simulator for testing purposes"""
 
     def __init__(
-        self,
-        parameters_range: dict[str, tuple[float, float]],
-        output_names: list[str],
+        self, parameters_range: dict[str, tuple[float, float]], output_names: list[str]
     ):
         # Call parent constructor
         super().__init__(parameters_range, output_names)
@@ -90,7 +88,7 @@ def test_sample_inputs(mock_simulator):
 def test_forward(mock_simulator):
     """Test that forward method works correctly"""
     # Create test input
-    test_input = torch.tensor([[0.5, 0.0, 7.5]], dtype=torch.float32)
+    test_input = torch.tensor([[0.5, 0.0, 7.5]], dtype=TorchDefaultDType)
 
     # Get output
     output = mock_simulator.forward(test_input)
@@ -109,7 +107,7 @@ def test_forward_batch(mock_simulator):
     # Create test batch
     n_samples = 3
     batch = torch.tensor(
-        [[0.5, 0.0, 7.5], [0.2, 0.3, 6.0], [0.8, -0.5, 9.0]], dtype=torch.float32
+        [[0.5, 0.0, 7.5], [0.2, 0.3, 6.0], [0.8, -0.5, 9.0]], dtype=TorchDefaultDType
     )
 
     # Process batch
@@ -183,7 +181,7 @@ def test_handle_simulation_failure():
             [0.1, 0.5, 0.5],  # Below threshold
             [0.7, 0.5, 0.5],  # Above threshold
         ],
-        dtype=torch.float32,
+        dtype=TorchDefaultDType,
     )
 
     # This should process all samples without errors

--- a/tests/experimental/test_experimental_preprocessors.py
+++ b/tests/experimental/test_experimental_preprocessors.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from autoemulate.experimental.data.preprocessors import Standardizer
+from autoemulate.experimental.types import TorchDefaultDType
 
 
 class TestStandardizer:
@@ -37,7 +38,7 @@ class TestStandardizer:
         Test that small std values are replaced with 1.0.
         """
         mean = torch.zeros((1, 2))
-        std = torch.tensor([[1e-40, 2.0]], dtype=torch.float32)
+        std = torch.tensor([[1e-40, 2.0]], dtype=TorchDefaultDType)
         s = Standardizer(mean, std)
         assert s.std[0, 0] == 1.0
         assert s.std[0, 1] == 2.0


### PR DESCRIPTION
Closes #537.

This PR:
- Adds `TorchDefaultDType = tf.float32` for use as a const across codebase
- Adds some dtype handling for simulators so that returned `y` has same dtype as input `x`

Question:
- An alternative would be to allow dtype for outputs and inputs of simulator to be set on the `__init__` - would this be useful?
- I replaced `.float32` where I think it makes sense but there could be other places such as in tutorials where there is some handling missing.