### PR TITLE
Fix missing model config to pass to cv

### DIFF
--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -84,11 +84,11 @@ def cross_validate(  # noqa: PLR0913
     cv: BaseCrossValidator,
     dataset: Dataset,
     model: type[Emulator],
+    model_config: ModelConfig,
     x_transforms: list[AutoEmulateTransform] | None = None,
     y_transforms: list[AutoEmulateTransform] | None = None,
     device: DeviceLike = "cpu",
     random_seed: int | None = None,
-    **kwargs: Any,
 ):
     """
     Cross validate model performance using the given `cv` strategy.
@@ -102,6 +102,8 @@ def cross_validate(  # noqa: PLR0913
         The data to use for model training and validation.
     model: Emulator
         An instance of an Emulator subclass.
+    model_config: ModelConfig
+        Hyperparameters and model config to be used to construct model upon initialize.
     device: DeviceLike
         The device to use for model training and evaluation.
     random_seed: int | None
@@ -112,7 +114,6 @@ def cross_validate(  # noqa: PLR0913
     dict[str, list[float]]
        Contains r2 and rmse scores computed for each cross validation fold.
     """
-    best_model_config: ModelConfig = kwargs
     x_transforms = x_transforms or []
     y_transforms = y_transforms or []
     cv_results = {"r2": [], "rmse": []}
@@ -136,7 +137,7 @@ def cross_validate(  # noqa: PLR0913
         if random_seed is not None:
             set_random_seed(seed=random_seed)
         model_init_params = inspect.signature(model).parameters
-        model_kwargs = dict(best_model_config)
+        model_kwargs = dict(model_config)
         if "random_seed" in model_init_params:
             model_kwargs["random_seed"] = random_seed
 

--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -1,7 +1,6 @@
 import inspect
 import logging
 from functools import partial
-from typing import Any
 
 import torch
 import torchmetrics

--- a/autoemulate/experimental/model_selection.py
+++ b/autoemulate/experimental/model_selection.py
@@ -102,7 +102,8 @@ def cross_validate(  # noqa: PLR0913
     model: Emulator
         An instance of an Emulator subclass.
     model_config: ModelConfig
-        Hyperparameters and model config to be used to construct model upon initialize.
+        Model parameters to be used to construct model upon initialization. Passing an
+        empty dictionary `{}` will use default parameters.
     device: DeviceLike
         The device to use for model training and evaluation.
     random_seed: int | None

--- a/autoemulate/experimental/tuner.py
+++ b/autoemulate/experimental/tuner.py
@@ -105,9 +105,9 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                 x_transforms=x_transforms,
                 y_transforms=y_transforms,
                 model=model_class,
+                model_config=model_config,
                 device=self.device,
                 random_seed=None,
-                **model_config,
             )
             model_config_tested.append(model_config)
             val_scores.append(scores["r2"])  # type: ignore  # noqa: PGH003

--- a/autoemulate/experimental/tuner.py
+++ b/autoemulate/experimental/tuner.py
@@ -107,6 +107,7 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                 model=model_class,
                 device=self.device,
                 random_seed=None,
+                **model_config,
             )
             model_config_tested.append(model_config)
             val_scores.append(scores["r2"])  # type: ignore  # noqa: PGH003

--- a/tests/experimental/test_experimental_model_selection.py
+++ b/tests/experimental/test_experimental_model_selection.py
@@ -48,7 +48,7 @@ def test_cross_validate():
     emulator_cls = DummyEmulator
 
     # KFold
-    results = cross_validate(KFold(n_splits=2), dataset, emulator_cls)
+    results = cross_validate(KFold(n_splits=2), dataset, emulator_cls, {})
     assert "r2" in results
     assert "rmse" in results
     assert len(results["r2"]) == 2
@@ -56,7 +56,7 @@ def test_cross_validate():
 
     # LeavePOut: LOO raised an error with torchmetrics R2Score since it requires at
     # least 2 samples
-    results = cross_validate(LeavePOut(p=2), dataset, emulator_cls)
+    results = cross_validate(LeavePOut(p=2), dataset, emulator_cls, {})
     expected_n = (x.shape[0] * (x.shape[0] - 1)) / 2
     assert len(results["r2"]) == expected_n
     assert len(results["rmse"]) == expected_n


### PR DESCRIPTION
Following https://github.com/alan-turing-institute/autoemulate/issues/454#issuecomment-3072519163, fixed missing random config to be passed to cv.