### PR TITLE
Revise GP predict approach

### DIFF
--- a/autoemulate/experimental/emulators/base.py
+++ b/autoemulate/experimental/emulators/base.py
@@ -281,10 +281,10 @@ class GaussianProcessEmulator(GaussianEmulator):
     """
 
     @abstractmethod
-    def _predict(self, x: TensorLike, with_grad: bool) -> GaussianProcessLike: ...
-    def predict(self, x: TensorLike, with_grad: bool = False) -> GaussianProcessLike:
+    def _predict(self, x: TensorLike, with_grad: bool) -> GaussianLike: ...
+    def predict(self, x: TensorLike, with_grad: bool = False) -> GaussianLike:
         pred = super().predict(x, with_grad)
-        assert isinstance(pred, GaussianProcessLike)
+        assert isinstance(pred, GaussianLike)
         return pred
 
 

--- a/autoemulate/experimental/emulators/base.py
+++ b/autoemulate/experimental/emulators/base.py
@@ -14,7 +14,6 @@ from autoemulate.experimental.device import TorchDeviceMixin
 from autoemulate.experimental.types import (
     DistributionLike,
     GaussianLike,
-    GaussianProcessLike,
     NumpyLike,
     OutputLike,
     TensorLike,

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -230,7 +230,7 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
                 x_batch = x[i : i + max_batch_size]
 
                 # Get predictive output with full covariance between points and tasks
-                output = self(x)
+                output = self(x_batch)
                 if self.posterior_predictive:
                     output = self.likelihood(output)
                 assert isinstance(output, GaussianProcessLike)

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -19,6 +19,7 @@ from autoemulate.experimental.emulators.gaussian_process import (
     CovarModuleFn,
     MeanModuleFn,
 )
+from autoemulate.experimental.transforms.utils import make_positive_definite
 from autoemulate.experimental.types import (
     DeviceLike,
     GaussianLike,
@@ -254,7 +255,10 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
             # Concatenate batches
             means = torch.cat(means_list, dim=0)  # (num_points, num_tasks)
             covs = torch.cat(covs_list, dim=0)  # (num_points, num_tasks, num_tasks)
-            return GaussianLike(means, covariance_matrix=covs)
+
+            # TODO: consider if clamp_eigval is  correct or should be applied within
+            # transforms
+            return GaussianLike(means, make_positive_definite(covs, clamp_eigvals=True))
 
     @staticmethod
     def get_tune_config():

--- a/tests/experimental/test_experimental_transformed.py
+++ b/tests/experimental/test_experimental_transformed.py
@@ -15,7 +15,6 @@ from autoemulate.experimental.transforms import (
 from autoemulate.experimental.types import (
     DistributionLike,
     GaussianLike,
-    GaussianProcessLike,
     TensorLike,
 )
 

--- a/tests/experimental/test_experimental_transformed.py
+++ b/tests/experimental/test_experimental_transformed.py
@@ -234,8 +234,8 @@ def test_inverse_gaussian_and_sample_pca(sample_data_y2d, new_data_y2d):
     y_pred2 = em.y_transforms[0]._inverse_sample(
         z_pred, n_samples=10000, full_covariance=True
     )
-    assert isinstance(y_pred, GaussianProcessLike)
-    assert isinstance(y_pred2, GaussianProcessLike)
+    assert isinstance(y_pred, GaussianLike)
+    assert isinstance(y_pred2, GaussianLike)
     print()
     print(y_pred.covariance_matrix)
     print(y_pred2.covariance_matrix)


### PR DESCRIPTION
Closes #634:

This PR:
- Revises the `._predict` and `.predict` methods for GPs to return batches of independent `MultivariateNormal` (`GaussianLike`) (since covariance between test data points is not required, only task covariance needs to be captured)
- Uses batches to enable prediction over large number of points at inference time
- Adds `gpytorch.settings.fast_pred_var()` for predictions