### PR TITLE
Add fixes from further testing and benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ docs/data/simulator_results.csv
 
 # Ignore experimental exploratory data path
 autoemulate/experimental/exploratory/data
+
+# Ignore case studies data by default
+case_studies/**/data/
+
+# Benchmarking data
+benchmarks/data/

--- a/autoemulate/experimental/compare.py
+++ b/autoemulate/experimental/compare.py
@@ -253,6 +253,8 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                     unit="model",
                     unit_scale=True,
                 ):
+                    # Since refitting the model can fail after tuning, max_retries
+                    # is used to retry the whole tuning and fitting process
                     for attempt in range(self.max_retries):
                         try:
                             self.logger.info(
@@ -304,8 +306,8 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 device=self.device,
                                 **best_config_for_this_model,
                             )
-                            # This can fail for some model configurations,
-                            # catch and rerun
+
+                            # This can fail for some model configurations
                             transformed_emulator.fit(train_val_x, train_val_y)
 
                             (
@@ -356,7 +358,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 rmse_train_std=rmse_train_val_std,
                             )
                             self.add_result(result)
-                            # Exit retry loop
+                            # if successful, break out of the retry loop
                             break
                         except Exception as e:
                             self.logger.warning(

--- a/autoemulate/experimental/compare.py
+++ b/autoemulate/experimental/compare.py
@@ -269,7 +269,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                         shuffle=self.shuffle,
                     )
                     mean_scores = [np.mean(score).item() for score in scores]
-                    best_score_idx = scores.index(max(mean_scores))
+                    best_score_idx = np.argmax(mean_scores)
                     best_config_for_this_model = configs[best_score_idx]
                     self.logger.debug(
                         'Tuner found best config for model "%s": %s with score: %s',

--- a/autoemulate/experimental/compare.py
+++ b/autoemulate/experimental/compare.py
@@ -42,6 +42,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         n_splits: int = 5,
         shuffle: bool = True,
         n_bootstraps: int = 100,
+        max_retries: int = 3,
         device: DeviceLike | None = None,
         random_seed: int | None = None,
         log_level: str = "progress_bar",
@@ -131,6 +132,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         self.shuffle = shuffle
         self.n_iter = n_iter
         self.n_bootstraps = n_bootstraps
+        self.max_retries = max_retries
 
         # Set up logger and ModelSerialiser for saving models
         self.logger, self.progress_bar = get_configured_logger(log_level)
@@ -251,94 +253,125 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                     unit="model",
                     unit_scale=True,
                 ):
-                    self.logger.info(
-                        "Running Model: %s: %d/%d",
-                        model_cls.__name__,
-                        id,
-                        len(self.models),
-                    )
+                    for attempt in range(self.max_retries):
+                        try:
+                            self.logger.info(
+                                "Running Model: %s: %d/%d (attempt %d/%d)",
+                                model_cls.__name__,
+                                id,
+                                len(self.models),
+                                attempt + 1,
+                                self.max_retries,
+                            )
 
-                    self.logger.debug(
-                        'Running tuner for model "%s"', model_cls.__name__
-                    )
-                    scores, configs = tuner.run(
-                        model_cls,
-                        x_transforms,
-                        y_transforms,
-                        n_splits=self.n_splits,
-                        shuffle=self.shuffle,
-                    )
-                    mean_scores = [np.mean(score).item() for score in scores]
-                    best_score_idx = np.argmax(mean_scores)
-                    best_config_for_this_model = configs[best_score_idx]
-                    self.logger.debug(
-                        'Tuner found best config for model "%s": %s with score: %s',
-                        model_cls.__name__,
-                        best_config_for_this_model,
-                        scores[best_score_idx],
-                    )
+                            self.logger.debug(
+                                'Running tuner for model "%s"', model_cls.__name__
+                            )
+                            scores, configs = tuner.run(
+                                model_cls,
+                                x_transforms,
+                                y_transforms,
+                                n_splits=self.n_splits,
+                                shuffle=self.shuffle,
+                            )
+                            mean_scores = [np.mean(score).item() for score in scores]
+                            best_score_idx = np.argmax(mean_scores)
+                            best_config_for_this_model = configs[best_score_idx]
+                            self.logger.debug(
+                                'Tuner found best config for model "%s": '
+                                "%s with score: %.3f",
+                                model_cls.__name__,
+                                best_config_for_this_model,
+                                mean_scores[best_score_idx],
+                            )
 
-                    self.logger.debug(
-                        'Running cross-validation for model "%s" for "%s" iterations',
-                        model_cls.__name__,
-                        self.n_iter,
-                    )
-                    train_val_x, train_val_y = self._convert_to_tensors(self.train_val)
-                    test_x, test_y = self._convert_to_tensors(self.test)
-                    transformed_emulator = TransformedEmulator(
-                        train_val_x,
-                        train_val_y,
-                        model=model_cls,
-                        x_transforms=x_transforms,
-                        y_transforms=y_transforms,
-                        device=self.device,
-                        **best_config_for_this_model,
-                    )
-                    transformed_emulator.fit(train_val_x, train_val_y)
-                    (
-                        (r2_train_val, r2_train_val_std),
-                        (rmse_train_val, rmse_train_val_std),
-                    ) = bootstrap(
-                        transformed_emulator,
-                        train_val_x,
-                        train_val_y,
-                        n_bootstraps=self.n_bootstraps,
-                        device=self.device,
-                    )
-                    (r2_test, r2_test_std), (rmse_test, rmse_test_std) = bootstrap(
-                        transformed_emulator,
-                        test_x,
-                        test_y,
-                        n_bootstraps=self.n_bootstraps,
-                        device=self.device,
-                    )
+                            self.logger.debug(
+                                'Running cross-validation for model "%s" '
+                                'for "%s" iterations',
+                                model_cls.__name__,
+                                self.n_iter,
+                            )
+                            train_val_x, train_val_y = self._convert_to_tensors(
+                                self.train_val
+                            )
+                            test_x, test_y = self._convert_to_tensors(self.test)
+                            transformed_emulator = TransformedEmulator(
+                                train_val_x,
+                                train_val_y,
+                                model=model_cls,
+                                x_transforms=x_transforms,
+                                y_transforms=y_transforms,
+                                device=self.device,
+                                **best_config_for_this_model,
+                            )
+                            # This can fail for some model configurations,
+                            # catch and rerun
+                            transformed_emulator.fit(train_val_x, train_val_y)
 
-                    self.logger.debug(
-                        'Cross-validation for model "%s"'
-                        " completed with R2 score: %.3f (%.3f), "
-                        "RMSE score: %.3f (%.3f)",
-                        model_cls.__name__,
-                        r2_test,
-                        r2_test_std,
-                        rmse_test,
-                        rmse_test_std,
-                    )
-                    self.logger.info("Finished running Model: %s\n", model_cls.__name__)
-                    result = Result(
-                        id=id,
-                        model_name=transformed_emulator.untransformed_model_name,
-                        model=transformed_emulator,
-                        config=best_config_for_this_model,
-                        r2_test=r2_test,
-                        rmse_test=rmse_test,
-                        r2_test_std=r2_test_std,
-                        rmse_test_std=rmse_test_std,
-                        r2_train=r2_train_val,
-                        rmse_train=rmse_train_val,
-                        r2_train_std=r2_train_val_std,
-                        rmse_train_std=rmse_train_val_std,
-                    )
-                    self.add_result(result)
+                            (
+                                (r2_train_val, r2_train_val_std),
+                                (rmse_train_val, rmse_train_val_std),
+                            ) = bootstrap(
+                                transformed_emulator,
+                                train_val_x,
+                                train_val_y,
+                                n_bootstraps=self.n_bootstraps,
+                                device=self.device,
+                            )
+                            (r2_test, r2_test_std), (rmse_test, rmse_test_std) = (
+                                bootstrap(
+                                    transformed_emulator,
+                                    test_x,
+                                    test_y,
+                                    n_bootstraps=self.n_bootstraps,
+                                    device=self.device,
+                                )
+                            )
+
+                            self.logger.debug(
+                                'Cross-validation for model "%s"'
+                                " completed with test mean (std) R2 score: %.3f (%.3f),"
+                                " mean (std) RMSE score: %.3f (%.3f)",
+                                model_cls.__name__,
+                                r2_test,
+                                r2_test_std,
+                                rmse_test,
+                                rmse_test_std,
+                            )
+                            self.logger.info(
+                                "Finished running Model: %s\n", model_cls.__name__
+                            )
+                            result = Result(
+                                id=id,
+                                model_name=transformed_emulator.untransformed_model_name,
+                                model=transformed_emulator,
+                                config=best_config_for_this_model,
+                                r2_test=r2_test,
+                                rmse_test=rmse_test,
+                                r2_test_std=r2_test_std,
+                                rmse_test_std=rmse_test_std,
+                                r2_train=r2_train_val,
+                                rmse_train=rmse_train_val,
+                                r2_train_std=r2_train_val_std,
+                                rmse_train_std=rmse_train_val_std,
+                            )
+                            self.add_result(result)
+                            # Exit retry loop
+                            break
+                        except Exception as e:
+                            self.logger.warning(
+                                "Model %s failed on attempt %d/%d: %s",
+                                model_cls.__name__,
+                                attempt + 1,
+                                self.max_retries,
+                                str(e),
+                            )
+                            if attempt == self.max_retries - 1:
+                                self.logger.error(
+                                    "Model %s failed after %d attempts, skipping.",
+                                    model_cls.__name__,
+                                    self.max_retries,
+                                )
 
         # Get the best result and log the comparison
         best_result = self.best_result()

--- a/autoemulate/experimental/compare.py
+++ b/autoemulate/experimental/compare.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import tqdm
 
@@ -267,7 +268,8 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                         n_splits=self.n_splits,
                         shuffle=self.shuffle,
                     )
-                    best_score_idx = scores.index(max(scores))
+                    mean_scores = [np.mean(score).item() for score in scores]
+                    best_score_idx = scores.index(max(mean_scores))
                     best_config_for_this_model = configs[best_score_idx]
                     self.logger.debug(
                         'Tuner found best config for model "%s": %s with score: %s',

--- a/autoemulate/experimental/emulators/__init__.py
+++ b/autoemulate/experimental/emulators/__init__.py
@@ -8,6 +8,7 @@ from .nn.mlp import MLP
 from .radial_basis_functions import RadialBasisFunctions
 from .random_forest import RandomForest
 from .svm import SupportVectorMachine
+from .transformed.base import TransformedEmulator
 
 ALL_EMULATORS: list[type[Emulator]] = [
     GaussianProcessExact,
@@ -50,3 +51,17 @@ def get_emulator_class(name: str) -> type[Emulator]:
         )
 
     return emulator_cls
+
+
+__all__ = [
+    "MLP",
+    "EnsembleMLP",
+    "EnsembleMLPDropout",
+    "GaussianProcessExact",
+    "GaussianProcessExactCorrelated",
+    "LightGBM",
+    "RadialBasisFunctions",
+    "RandomForest",
+    "SupportVectorMachine",
+    "TransformedEmulator",
+]

--- a/autoemulate/experimental/emulators/ensemble.py
+++ b/autoemulate/experimental/emulators/ensemble.py
@@ -149,10 +149,7 @@ class EnsembleMLP(Ensemble):
         **mlp_kwargs: dict
             Additional keyword arguments for the MLP constructor.
         """
-        emulators = [
-            MLP(x, y, random_seed=i, device=device, **mlp_kwargs)
-            for i in range(n_emulators)
-        ]
+        emulators = [MLP(x, y, device=device, **mlp_kwargs) for i in range(n_emulators)]
         super().__init__(emulators, device=device)
 
     @staticmethod

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -289,24 +289,6 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
         ]
         return np.random.choice(all_params)
 
-    @classmethod
-    def scheduler_config(cls) -> dict:
-        """
-        Returns a random configuration for the learning rate scheduler.
-        This should be added to the `get_tune_config()` method of subclasses
-        to allow tuning of the scheduler parameters.
-        """
-        all_params = [
-            {"scheduler_cls": None, "scheduler_kwargs": None},
-            {
-                "scheduler_cls": [LRScheduler],
-                "scheduler_kwargs": [
-                    {"policy": "ReduceLROnPlateau", "patience": 5, "factor": 0.5}
-                ],
-            },
-        ]
-        return np.random.choice(all_params)
-
     @staticmethod
     def get_tune_config():
         scheduler_config = GaussianProcessExact.scheduler_config()

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -94,7 +94,7 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
             False, it will return the posterior distribution over the modelled function.
         epochs: int, default=50
             Number of training epochs.
-        lr : float, default=2e-1
+        lr: float, default=2e-1
             Learning rate for the optimizer.
         early_stopping: EarlyStopping | None
             An optional EarlyStopping callback. Defaults to None.

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -54,7 +54,7 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
     # TODO: refactor to work more like PyTorchBackend once any subclasses implemented
     optimizer_cls: type[optim.Optimizer] = optim.AdamW
     optimizer: optim.Optimizer
-    lr: float = 1e-1
+    lr: float = 2e-1
     scheduler_cls: type[LRScheduler] | None = None
 
     def __init__(  # noqa: PLR0913 allow too many arguments since all currently required
@@ -67,7 +67,7 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
         posterior_predictive: bool = False,
         epochs: int = 50,
         activation: type[nn.Module] = nn.ReLU,
-        lr: float = 2e-1,
+        lr: float = 1e-1,
         early_stopping: EarlyStopping | None = None,
         device: DeviceLike | None = None,
         **kwargs,

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -66,7 +66,7 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
         covar_module_fn: CovarModuleFn = rbf_plus_constant,
         posterior_predictive: bool = False,
         epochs: int = 50,
-        lr: float = 1e-1,
+        lr: float = 2e-1,
         early_stopping: EarlyStopping | None = None,
         device: DeviceLike | None = None,
         **kwargs,

--- a/autoemulate/experimental/emulators/gaussian_process/exact.py
+++ b/autoemulate/experimental/emulators/gaussian_process/exact.py
@@ -271,24 +271,6 @@ class GaussianProcessExact(GaussianProcessEmulator, gpytorch.models.ExactGP):
             assert output_distribution.event_shape == torch.Size([num_tasks])
             return output_distribution
 
-    @classmethod
-    def scheduler_config(cls) -> dict:
-        """
-        Returns a random configuration for the learning rate scheduler.
-        This should be added to the `get_tune_config()` method of subclasses
-        to allow tuning of the scheduler parameters.
-        """
-        all_params = [
-            {"scheduler_cls": None, "scheduler_kwargs": None},
-            {
-                "scheduler_cls": [LRScheduler],
-                "scheduler_kwargs": [
-                    {"policy": "ReduceLROnPlateau", "patience": 5, "factor": 0.5}
-                ],
-            },
-        ]
-        return np.random.choice(all_params)
-
     @staticmethod
     def get_tune_config():
         scheduler_config = GaussianProcessExact.scheduler_config()

--- a/autoemulate/experimental/emulators/nn/mlp.py
+++ b/autoemulate/experimental/emulators/nn/mlp.py
@@ -114,14 +114,17 @@ class MLP(DropoutTorchBackend):
     def get_tune_config():
         scheduler_params = MLP.scheduler_config()
         return {
-            "epochs": [50, 100, 200],
-            "layer_dims": [[32, 16], [64, 32, 16]],
-            "lr": [1e-1, 1e-2, 1e-3],
+            # "epochs": [50, 100, 200],
+            "epochs": [100, 200],
+            # "layer_dims": [[32, 16], [64, 32, 16]],
+            "layer_dims": [[8, 4], [16, 8], [32, 16]],
+            # "lr": [5e-1, 2e-1, 1e-1, 1e-2, 1e-3],
+            "lr": [5e-1, 2e-1, 1e-1, 1e-2],
             "batch_size": [16, 32],
             "weight_init": ["default", "normal"],
             "scale": [0.1, 1.0],
             "bias_init": ["default", "zeros"],
-            "dropout_prob": [0.3, 0.5, None],
+            "dropout_prob": [0.3, None],
             "scheduler_cls": scheduler_params["scheduler_cls"],
             "scheduler_kwargs": scheduler_params["scheduler_kwargs"],
         }

--- a/autoemulate/experimental/emulators/nn/mlp.py
+++ b/autoemulate/experimental/emulators/nn/mlp.py
@@ -119,7 +119,7 @@ class MLP(DropoutTorchBackend):
             # "layer_dims": [[32, 16], [64, 32, 16]],
             "layer_dims": [[8, 4], [16, 8], [32, 16]],
             # "lr": [5e-1, 2e-1, 1e-1, 1e-2, 1e-3],
-            "lr": [5e-1, 2e-1, 1e-1, 1e-2],
+            "lr": [5e-1, 2e-1, 1e-1, 1e-2, 1e-3],
             "batch_size": [16, 32],
             "weight_init": ["default", "normal"],
             "scale": [0.1, 1.0],

--- a/autoemulate/experimental/emulators/nn/mlp.py
+++ b/autoemulate/experimental/emulators/nn/mlp.py
@@ -114,11 +114,8 @@ class MLP(DropoutTorchBackend):
     def get_tune_config():
         scheduler_params = MLP.scheduler_config()
         return {
-            # "epochs": [50, 100, 200],
             "epochs": [100, 200],
-            # "layer_dims": [[32, 16], [64, 32, 16]],
-            "layer_dims": [[8, 4], [16, 8], [32, 16]],
-            # "lr": [5e-1, 2e-1, 1e-1, 1e-2, 1e-3],
+            "layer_dims": [[8, 4], [16, 8], [32, 16], [64, 32, 16]],
             "lr": [5e-1, 2e-1, 1e-1, 1e-2, 1e-3],
             "batch_size": [16, 32],
             "weight_init": ["default", "normal"],

--- a/autoemulate/experimental/simulations/__init__.py
+++ b/autoemulate/experimental/simulations/__init__.py
@@ -5,4 +5,4 @@ ALL_SIMULATORS = [Epidemic, Projectile, ProjectileMultioutput]
 
 __all__ = ["Epidemic", "Projectile", "ProjectileMultioutput"]
 
-SIMULATOR_FROM_STR = dict(zip(__all__, ALL_SIMULATORS, strict=False))
+SIMULATOR_REGISTRY = dict(zip(__all__, ALL_SIMULATORS, strict=False))

--- a/autoemulate/experimental/simulations/__init__.py
+++ b/autoemulate/experimental/simulations/__init__.py
@@ -1,0 +1,8 @@
+from .epidemic import Epidemic
+from .projectile import Projectile, ProjectileMultioutput
+
+ALL_SIMULATORS = [Epidemic, Projectile, ProjectileMultioutput]
+
+__all__ = ["Epidemic", "Projectile", "ProjectileMultioutput"]
+
+SIMULATOR_FROM_STR = dict(zip(__all__, ALL_SIMULATORS, strict=False))

--- a/autoemulate/experimental/simulations/base.py
+++ b/autoemulate/experimental/simulations/base.py
@@ -50,6 +50,10 @@ class Simulator(ABC, ValidationMixin):
         self._has_sample_forward = False
         self.logger, self.progress_bar = get_configured_logger(log_level)
 
+    @classmethod
+    def simulator_name(cls) -> str:
+        return cls.__name__
+
     @property
     def parameters_range(self) -> dict[str, tuple[float, float]]:
         """Dictionary mapping input parameter names to their (min, max) ranges."""

--- a/autoemulate/experimental/tuner.py
+++ b/autoemulate/experimental/tuner.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import numpy as np
 from sklearn.model_selection import KFold
 from torchmetrics import R2Score
 
@@ -97,12 +98,6 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
 
         i = 0
         while i < self.n_iter:
-            logger.debug(
-                "Tuning Model: Iteration %s: %d/%d",
-                model_class.__name__,
-                i + 1,
-                self.n_iter,
-            )
             # randomly sample hyperparameters and instantiate model
             model_config = model_class.get_random_config()
             try:
@@ -119,6 +114,17 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                 model_config_tested.append(model_config)
                 val_scores.append(scores["r2"])  # type: ignore  # noqa: PGH003
                 i += 1
+                logger.debug(
+                    "tuning model: %s; iteration: %d/%d; mean (std) r2=%.3f (%.3f); "
+                    "model_config: %s",
+                    model_class.model_name(),
+                    i + 1,
+                    self.n_iter,
+                    np.mean(scores["r2"]),
+                    np.std(scores["r2"]),
+                    str(model_config),
+                )
+
             except Exception as e:
                 # Retry with new random config parameters
                 logger.warning(

--- a/autoemulate/experimental/tuner.py
+++ b/autoemulate/experimental/tuner.py
@@ -113,6 +113,7 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                 model_config=model_config,
                 device=self.device,
                 random_seed=None,
+                **model_config,
             )
             model_config_tested.append(model_config)
             val_scores.append(scores["r2"])  # type: ignore  # noqa: PGH003

--- a/autoemulate/experimental/tuner.py
+++ b/autoemulate/experimental/tuner.py
@@ -115,7 +115,6 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                     model_config=model_config,
                     device=self.device,
                     random_seed=None,
-                    **model_config,
                 )
                 model_config_tested.append(model_config)
                 val_scores.append(scores["r2"])  # type: ignore  # noqa: PGH003
@@ -128,6 +127,5 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                     json.dumps(model_config, default=str, separators=(",", ":")),
                     str(e),
                 )
-                continue
 
         return val_scores, model_config_tested


### PR DESCRIPTION
Closes #644.

This PR:
- Captures the same commits as #621 but without the benchmarking since this is still in progress
- Adds fixes and functionality described in https://github.com/alan-turing-institute/autoemulate/pull/621#issuecomment-3106466642
- Adds retry logic for a given model in case the tuner returns config that results in exception upon refit [31a59d7](https://github.com/alan-turing-institute/autoemulate/pull/647/commits/31a59d78e72e18fa2c6db9b4553139db4b8ce6b5)