### PR TITLE
Add API to update simulator parameters and enable sampling when equal bounds

### DIFF
--- a/autoemulate/experimental/simulations/base.py
+++ b/autoemulate/experimental/simulations/base.py
@@ -59,6 +59,22 @@ class Simulator(ABC, ValidationMixin):
         """Dictionary mapping input parameter names to their (min, max) ranges."""
         return self._parameters_range
 
+    @parameters_range.setter
+    def parameters_range(
+        self, parameters_range: dict[str, tuple[float, float]]
+    ) -> None:
+        """Set the range of input parameters for the simulator.
+
+        Parameters
+        ----------
+        parameters_range: dict[str, tuple[float, float]]
+            Dictionary mapping input parameter names to their (min, max) ranges.
+        """
+        self._parameters_range = parameters_range
+        self._param_names = list(parameters_range.keys())
+        self._param_bounds = list(parameters_range.values())
+        self._in_dim = len(self.param_names)
+
     @property
     def param_names(self) -> list[str]:
         """List of parameter names."""
@@ -73,6 +89,33 @@ class Simulator(ABC, ValidationMixin):
     def output_names(self) -> list[str]:
         """List of output parameter names."""
         return self._output_names
+
+    @output_names.setter
+    def output_names(self, output_names: list[str]) -> None:
+        """Set the names of output parameters for the simulator.
+
+        This setter allows renaming the output parameters but does not allow
+        changing the number of outputs (dimensionality is fixed after initialization).
+
+        Parameters
+        ----------
+        output_names: list[str]
+            List of output parameter names. Must have the same length as the current
+            number of outputs.
+
+        Raises
+        ------
+        ValueError
+            If the number of output names differs from the simulator's fixed output
+            dimension.
+        """
+        if len(output_names) != self._out_dim:
+            raise ValueError(
+                f"Number of output names ({len(output_names)}) must match "
+                f"simulator output dimension ({self._out_dim}). Cannot change "
+                f"dimensionality after initialization."
+            )
+        self._output_names = output_names
 
     @property
     def in_dim(self) -> int:

--- a/tests/experimental/test_experimental_base_simulator.py
+++ b/tests/experimental/test_experimental_base_simulator.py
@@ -194,3 +194,33 @@ def test_handle_simulation_failure():
     # Verify results shape
     assert results.shape == (2, 1)
     assert valid_x.shape == (2, 3)
+
+
+def test_update_parameters_range(mock_simulator):
+    """Test that parameters_range can be updated"""
+    new_range = {"param1": (0.1, 0.9), "param2": (-0.5, 0.5), "param3": (4.0, 6.0)}
+    mock_simulator.parameters_range = new_range
+    assert mock_simulator.parameters_range == new_range
+    assert mock_simulator.param_bounds == list(new_range.values())
+    assert mock_simulator.in_dim == len(new_range)
+
+
+def test_update_output_names(mock_simulator):
+    """Test that output_names can be updated with same number of outputs"""
+    new_output_names = ["var1_new", "var2_new"]
+    mock_simulator.output_names = new_output_names
+    assert mock_simulator.output_names == new_output_names
+    assert mock_simulator.out_dim == 2
+
+
+def test_update_output_names_wrong_dimension(mock_simulator):
+    """Test that setting output_names with wrong dimension raises error"""
+    with pytest.raises(ValueError, match="Number of output names \\(1\\) must match"):
+        mock_simulator.output_names = ["only_one_var"]
+
+    with pytest.raises(ValueError, match="Number of output names \\(3\\) must match"):
+        mock_simulator.output_names = ["var1", "var2", "var3"]
+
+    # Verify original names are unchanged after failed attempts
+    assert mock_simulator.output_names == ["var1", "var2"]
+    assert mock_simulator.out_dim == 2

--- a/tests/experimental/test_experimental_design.py
+++ b/tests/experimental/test_experimental_design.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from autoemulate.experimental_design import ExperimentalDesign
+from autoemulate.experimental_design import LatinHypercube
+
+
+# Test LatinHypercube Initialisation
+@pytest.fixture
+def lh():
+    return LatinHypercube([(0.0, 1.0), (10.0, 100.0)])
+
+
+def test_init(lh):
+    assert lh is not None
+
+
+def test_parameters(lh):
+    assert lh.get_n_parameters() == 2
+
+
+# Test LatinHypercube Sampling
+@pytest.fixture
+def lh_sample(lh):
+    return lh.sample(3)
+
+
+def test_sample_shape(lh_sample):
+    assert lh_sample.shape == (3, 2)
+
+
+def test_sample_lower_bound_par1(lh_sample):
+    assert np.all(lh_sample[:, 0] >= 0.0)
+
+
+def test_sample_upper_bound_par1(lh_sample):
+    assert np.all(lh_sample[:, 0] <= 1.0)
+
+
+def test_sample_lower_bound_par2(lh_sample):
+    assert np.all(lh_sample[:, 1] >= 10.0)

--- a/tests/experimental/test_experimental_design.py
+++ b/tests/experimental/test_experimental_design.py
@@ -1,12 +1,12 @@
-import numpy as np
 import pytest
-from autoemulate.experimental_design import LatinHypercube
+import torch
+from autoemulate.experimental.simulations.base import LatinHypercube
 
 
 # Test LatinHypercube Initialisation
 @pytest.fixture
 def lh():
-    return LatinHypercube([(0.0, 1.0), (10.0, 100.0)])
+    return LatinHypercube([(0.0, 1.0), (10.0, 100.0), (1000.0, 1000.0)])
 
 
 def test_init(lh):
@@ -14,26 +14,39 @@ def test_init(lh):
 
 
 def test_parameters(lh):
-    assert lh.get_n_parameters() == 2
+    assert lh.get_n_parameters() == 3
+
+
+@pytest.fixture
+def n_samples():
+    return 1_000
 
 
 # Test LatinHypercube Sampling
 @pytest.fixture
-def lh_sample(lh):
-    return lh.sample(3)
+def lh_sample(lh, n_samples):
+    return lh.sample(n_samples)
 
 
-def test_sample_shape(lh_sample):
-    assert lh_sample.shape == (3, 2)
+def test_sample_shape(lh_sample, n_samples):
+    assert lh_sample.shape == (n_samples, 3)
 
 
 def test_sample_lower_bound_par1(lh_sample):
-    assert np.all(lh_sample[:, 0] >= 0.0)
+    assert torch.all(lh_sample[:, 0] >= 0.0)
 
 
 def test_sample_upper_bound_par1(lh_sample):
-    assert np.all(lh_sample[:, 0] <= 1.0)
+    assert torch.all(lh_sample[:, 0] <= 1.0)
 
 
 def test_sample_lower_bound_par2(lh_sample):
-    assert np.all(lh_sample[:, 1] >= 10.0)
+    assert torch.all(lh_sample[:, 1] >= 10.0)
+
+
+def test_sample_upper_bound_par2(lh_sample):
+    assert torch.all(lh_sample[:, 1] <= 100.0)
+
+
+def test_sample_bound_par3(lh_sample):
+    assert torch.all(lh_sample[:, 2] == 1000.0)

--- a/tests/experimental/test_experimental_design.py
+++ b/tests/experimental/test_experimental_design.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pytest
-
-from autoemulate.experimental_design import ExperimentalDesign
 from autoemulate.experimental_design import LatinHypercube
 
 


### PR DESCRIPTION
Closes #659.

This PR:
- Adds custom setter methods for:
  - `parameter_ranges`: this updates the corresponding attributes that are set during initialization
  - `output_names`: this raises an error if new `output_names` has fewer outputs than at initialization (since this shouldn't change)
- Adds support for `LatinHypercube` sampling when parameters have equal upper and lower bounds
- Copies the `test_experimental_design.py` tests to `tests/experimental/` and updates to test equal bounds case and use torch