### PR TITLE
Add emulator info

### DIFF
--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -10,20 +10,13 @@ import tqdm
 from autoemulate.core.device import TorchDeviceMixin
 from autoemulate.core.logging_config import get_configured_logger
 from autoemulate.core.model_selection import bootstrap, evaluate, r2_metric
-from autoemulate.core.plotting import (
-    calculate_subplot_layout,
-    display_figure,
-    plot_xy,
-)
+from autoemulate.core.plotting import calculate_subplot_layout, display_figure, plot_xy
 from autoemulate.core.results import Result, Results
 from autoemulate.core.save import ModelSerialiser
 from autoemulate.core.tuner import Tuner
 from autoemulate.core.types import DeviceLike, DistributionLike, InputLike, ModelParams
 from autoemulate.data.utils import ConversionMixin, set_random_seed
-from autoemulate.emulators import (
-    ALL_EMULATORS,
-    get_emulator_class,
-)
+from autoemulate.emulators import ALL_EMULATORS, PYTORCH_EMULATORS, get_emulator_class
 from autoemulate.emulators.base import Emulator
 from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms.base import AutoEmulateTransform
@@ -175,6 +168,11 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         return pd.DataFrame(
             {
                 "Emulator": [emulator.model_name() for emulator in ALL_EMULATORS],
+                "PyTorch": [
+                    emulator in PYTORCH_EMULATORS for emulator in ALL_EMULATORS
+                ],
+                "MO": [emulator.is_multioutput() for emulator in ALL_EMULATORS],
+                "UQ": [emulator.uq for emulator in ALL_EMULATORS],
                 # TODO: short_name not currently used for anything, so commented out
                 # "short_name": [emulator.short_name() for emulator in ALL_EMULATORS],
             }

--- a/autoemulate/emulators/__init__.py
+++ b/autoemulate/emulators/__init__.py
@@ -23,6 +23,18 @@ ALL_EMULATORS: list[type[Emulator]] = [
     EnsembleMLPDropout,
 ]
 
+# listing non pytorch emulators as we do not expect this list to grow
+NON_PYTORCH_EMULATORS: list[type[Emulator]] = [
+    LightGBM,
+    RadialBasisFunctions,
+    RandomForest,
+]
+
+PYTORCH_EMULATORS: list[type[Emulator]] = [
+    emulator for emulator in ALL_EMULATORS if emulator not in NON_PYTORCH_EMULATORS
+]
+
+
 EMULATOR_REGISTRY = {em_cls.model_name().lower(): em_cls for em_cls in ALL_EMULATORS}
 EMULATOR_REGISTRY_SHORT_NAME = {em_cls.short_name(): em_cls for em_cls in ALL_EMULATORS}
 

--- a/autoemulate/emulators/base.py
+++ b/autoemulate/emulators/base.py
@@ -36,6 +36,7 @@ class Emulator(ABC, ValidationMixin, ConversionMixin, TorchDeviceMixin):
     scheduler_cls: type[optim.lr_scheduler.LRScheduler] | None = None
     x_transform: StandardizeTransform | None = None
     y_transform: StandardizeTransform | None = None
+    uq: bool = False
 
     @abstractmethod
     def _fit(self, x: TensorLike, y: TensorLike): ...
@@ -271,6 +272,8 @@ class Emulator(ABC, ValidationMixin, ConversionMixin, TorchDeviceMixin):
 class DeterministicEmulator(Emulator):
     """A base class for deterministic emulators."""
 
+    uq: bool = False
+
     @abstractmethod
     def _predict(self, x: TensorLike, with_grad: bool) -> TensorLike: ...
     def predict(self, x: TensorLike, with_grad: bool = False) -> TensorLike:
@@ -295,6 +298,8 @@ class DeterministicEmulator(Emulator):
 
 class ProbabilisticEmulator(Emulator):
     """A base class for probabilistic emulators."""
+
+    uq: bool = True
 
     @abstractmethod
     def _predict(self, x: TensorLike, with_grad: bool) -> DistributionLike: ...
@@ -415,6 +420,7 @@ class PyTorchBackend(nn.Module, Emulator):
     supports_grad: bool = True
     lr: float = 1e-1
     scheduler_cls: type[LRScheduler] | None = None
+    uq: bool = False
 
     def loss_func(self, y_pred, y_true):
         """Loss function to be used for training the model."""

--- a/docs/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/tutorials/emulation/01_quickstart.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "With our simulator inputs and outputs, we can run a full machine learning pipeline, including data processing, model fitting, model selection and hyperparameter optimisation in just a few lines of code.\n",
     "\n",
-    "First, let's import `AutoEmulate` and check the names of the available Emulator models.\n"
+    "First, let's import `AutoEmulate` and check the names of the available Emulator models. The columns indicate whether the emulator has a PyTorch backend, supports multioutput (`MO`) data and provides predictive uncertainty quantification (`UQ`).\n"
    ]
   },
   {
@@ -123,9 +123,15 @@
     "\n",
     "Specify models used by AutoEmulate with the `models` argument, for example:\n",
     "```python\n",
-    "from autoemulate.emulators import GaussianProcessExact, RadialBasisFunctions\n",
     "models = [\"GaussianProcessExact\", \"RadialBasisFunctions\"]\n",
     "ae = AutoEmulate(x, y, models=models)\n",
+    "```\n",
+    "\n",
+    "The user can also restrict the selection to just PyTorch models:\n",
+    "\n",
+    "```python\n",
+    "from autoemulate.emulators import PYTORCH_EMULATORS\n",
+    "ae = AutoEmulate(x, y, models=PYTORCH_EMULATORS)\n",
     "```\n",
     "\n",
     "</details>\n",
@@ -318,7 +324,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #552 

As suggested in the issue, I updated the `list_emulators()` method to return some info on each emulator similar to the table we have in the release (is it PyTorch, MO, UQ). I also added `PYTORCH_EMULATORS` list to  make it easier to select just this subset.