### PR TITLE
Use compare method in dim reduction tutorial

### DIFF
--- a/docs/tutorials/emulation/02_dim_reduction.ipynb
+++ b/docs/tutorials/emulation/02_dim_reduction.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "### Overview\n",
     "\n",
-    "Sometimes an emulator performs better when the input and/or the output dimensionality is reduced. In this example, we show how one can try different dimensionality reduction methods in combination with the emulators tested by AutoEmulate.\n",
+    "Sometimes an emulator performs better when the input and/or the output dimensionality is reduced. In this example, we show how one can specify dimensionality reduction methods to be used in combination with the emulators tested by AutoEmulate.\n",
     "\n",
     "###  Reaction-Diffusion example\n",
     "\n",
@@ -136,9 +136,9 @@
    "source": [
     "## 2: Fit an emulator on a subset of the data\n",
     "\n",
-    "Below we set up a `TransformedEmulator` object, which takes in an emulator model as well as a sequence on `x_transforms` and `y_transforms`. In this example we apply PCA to the simulation output and train a Gaussian Process emulator on this reduced problem space. This is often more efficient for high dimensional problems.\n",
+    "Below we pass a sequence of `x_transforms` and `y_transforms` to `AutoEmulate`. In this example we apply PCA to the simulation output and train a Gaussian Process emulator on this reduced problem space. This is often more efficient for high dimensional problems.\n",
     "\n",
-    "Note that different combinations of `x_transforms` and `y_transforms` can be passed directly to the `AutoEmulate` object before `compare()` is run, which will test all the different transform combinations with all the emulators. In addition to dimensionality reduction with PCA, `AutoEmulate` also has an option to use Variational Autoencoder."
+    "Note that the transforms are specified as a list of lists. This enables users to specify different transform combinations (each a list) to test with all the emulators. For example, a user could try PCA with different number of components. In addition to dimensionality reduction with PCA, `AutoEmulate` also has an option to use Variational Autoencoder."
    ]
   },
   {
@@ -147,43 +147,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from autoemulate.emulators.gaussian_process.exact import GaussianProcess\n",
-    "from autoemulate.emulators.gaussian_process.kernel import rbf_plus_constant\n",
-    "from autoemulate.emulators.gaussian_process.mean import constant_mean\n",
-    "from autoemulate.emulators.transformed.base import TransformedEmulator\n",
+    "from autoemulate.core.compare import AutoEmulate\n",
     "from autoemulate.transforms import *\n",
     "import torch \n",
     "\n",
     "# Convert to tensors\n",
     "x, y = torch.Tensor(X).float(), torch.Tensor(Y).float()\n",
     "\n",
-    "# Create a TransformedEmulator\n",
-    "em = TransformedEmulator(\n",
-    "    x,\n",
-    "    y,\n",
-    "    model= GaussianProcess,\n",
-    "    x_transforms=[StandardizeTransform()],\n",
-    "    y_transforms=[\n",
-    "        StandardizeTransform(),\n",
-    "        PCATransform(n_components=16),\n",
-    "        StandardizeTransform()\n",
-    "    ],\n",
-    "    epochs=50,\n",
-    "    lr=0.2,\n",
-    "    mean_module_fn=constant_mean,\n",
-    "    covar_module_fn=rbf_plus_constant,\n",
-    "    posterior_predictive=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Split into train/test data\n",
     "test_idx = [np.array([13, 39, 30, 45, 17, 48, 26, 25, 32, 19])]\n",
-    "train_idx = np.setdiff1d(np.arange(len(x)), test_idx)"
+    "train_idx = np.setdiff1d(np.arange(len(x)), test_idx)\n",
+    "\n",
+    "# Create a TransformedEmulator\n",
+    "ae = AutoEmulate(\n",
+    "    x[train_idx], \n",
+    "    y[train_idx],\n",
+    "    log_level=\"error\", \n",
+    "    models=[\"GaussianProcess\"],\n",
+    "    x_transforms_list=[[StandardizeTransform()]],\n",
+    "    y_transforms_list=[[StandardizeTransform(), PCATransform(n_components=16), StandardizeTransform()]])"
    ]
   },
   {
@@ -192,8 +174,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Fit on all data\n",
-    "em.fit(x[train_idx], y[train_idx])"
+    "ae.summarise()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Extract best performing emulator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "em = ae.best_result().model"
    ]
   },
   {
@@ -209,7 +206,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# Get predictions for the full dataset\n",
     "y_true = y[test_idx].numpy()\n",
     "y_pred_dis = em.predict(x[test_idx])\n",


### PR DESCRIPTION
Closes #668 

I updated the dimensionality reduction tutorial to use the main compare loop as that is what we want the users to learn from this tutorial (rather than how to instantiate a `TransformedEmulator` with a lot of customisation). The performance across the two implementations is comparable, the main difference is that the output of `compare()` has narrower uncertainties but this is the default `AutoEmulate` behaviour so should be what we demo.