### PR TITLE
Add AutoEmulate class to __init__ to allow import from top level of package. 

### DIFF
--- a/autoemulate/__init__.py
+++ b/autoemulate/__init__.py
@@ -1,0 +1,3 @@
+from .core.compare import AutoEmulate
+
+__all__ = ["AutoEmulate"]

--- a/docs/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/tutorials/emulation/01_quickstart.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from autoemulate.core.compare import AutoEmulate\n",
+    "from autoemulate import AutoEmulate\n",
     "\n",
     "AutoEmulate.list_emulators()"
    ]


### PR DESCRIPTION
This allows user to: 

`from autoemulate import Autoemulate` or 
```
import autoemulate as ae
ae.AutoEmulate(). . 
```