### PR TITLE
Add option to save plots to file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     env:
       TURN_OFF_MPS_IF_RUNNING_CI: 1
+      MPLBACKEND: Agg
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -437,7 +437,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         input_index: list[int] | int | None = None,
         output_index: list[int] | int | None = None,
         figsize=None,
-        n_cols: int = 3,
+        ncols: int = 3,
         fname: str | None = None,
     ):
         """
@@ -523,12 +523,12 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         n_plots = len(input_index) * len(output_index)
 
         # Calculate number of rows
-        n_rows, n_cols = calculate_subplot_layout(n_plots, n_cols)
+        nrows, ncols = calculate_subplot_layout(n_plots, ncols)
 
         # Set up the figure
         if figsize is None:
-            figsize = (5 * n_cols, 4 * n_rows)
-        fig, axs = plt.subplots(n_rows, n_cols, figsize=figsize, squeeze=False)
+            figsize = (5 * ncols, 4 * nrows)
+        fig, axs = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
         axs = axs.flatten()
 
         plot_index = 0

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -431,13 +431,14 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
             rmse_score=best_result.rmse_test,
         )
 
-    def plot(  # noqa: PLR0912, PLR0915
+    def plot(  # noqa: PLR0912, PLR0913, PLR0915
         self,
         model_obj: int | Emulator | Result,
         input_index: list[int] | int | None = None,
         output_index: list[int] | int | None = None,
         figsize=None,
         n_cols: int = 3,
+        fname: str | None = None,
     ):
         """
         Plot the evaluation of the model with the given result_id.
@@ -451,6 +452,13 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
             The index of the input feature to plot against the output.
         output_index: int
             The index of the output feature to plot against the input.
+        figsize: tuple[int, int] | None
+            The size of the figure to create. If None, it is set based on the number
+            of input and output features.
+        ncols: int
+            The number of columns in the subplot grid. Defaults to 3.
+        fname: str | None
+            If provided, the figure will be saved to this file path.
         """
         result = None
         if isinstance(model_obj, int):
@@ -545,7 +553,10 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
             ax.set_visible(False)
         plt.tight_layout()
 
-        return display_figure(fig)
+        if fname is None:
+            return display_figure(fig)
+        fig.savefig(fname, bbox_inches="tight")
+        return None
 
     def save(
         self,

--- a/autoemulate/core/sensitivity_analysis.py
+++ b/autoemulate/core/sensitivity_analysis.py
@@ -1,5 +1,6 @@
 import logging
 
+import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -247,9 +248,10 @@ class SensitivityAnalysis(ConversionMixin):
         index: str = "S1",
         n_cols: int | None = None,
         figsize: tuple | None = None,
+        fname: str | None = None,
     ):
         """
-        Plot Sobol sensitivity analysis results.
+        Plot Sobol sensitivity analysis results. Optionally save to file.
 
         Parameters
         ----------
@@ -267,8 +269,14 @@ class SensitivityAnalysis(ConversionMixin):
         figsize: tuple | None
             Figure size as (width, height) in inches. If None, set automatically.
             Defaults to None.
+        fname: str | None
+            If provided, saves the figure to this file path. Defaults to None.
         """
-        return _plot_sobol_analysis(results, index, n_cols, figsize)
+        fig = _plot_sobol_analysis(results, index, n_cols, figsize)
+        if fname is None:
+            return display_figure(fig)
+        fig.savefig(fname, bbox_inches="tight")
+        return None
 
     @staticmethod
     def plot_morris(
@@ -276,9 +284,10 @@ class SensitivityAnalysis(ConversionMixin):
         param_groups: dict[str, list[str]] | None = None,
         n_cols: int | None = None,
         figsize: tuple | None = None,
+        fname: str | None = None,
     ):
         """
-        Plot Morris analysis results.
+        Plot Morris analysis results. Optionally save to file.
 
         Parameters
         ----------
@@ -292,8 +301,14 @@ class SensitivityAnalysis(ConversionMixin):
             more outputs, otherwise the number of outputs.
         figsize: tuple, optional
             Figure size as (width, height) in inches.If None, set calculated.
+        fname: str | None
+            If provided, saves the figure to this file path. Defaults to None.
         """
-        return _plot_morris_analysis(results, param_groups, n_cols, figsize)
+        fig = _plot_morris_analysis(results, param_groups, n_cols, figsize)
+        if fname is None:
+            return display_figure(fig)
+        fig.savefig(fname, bbox_inches="tight")
+        return None
 
     @staticmethod
     def top_n_sobol_params(
@@ -438,7 +453,7 @@ def _plot_sobol_analysis(
     index: str = "S1",
     n_cols: int | None = None,
     figsize: tuple | None = None,
-):
+) -> matplotlib.figure.Figure:
     """
     Plot the sobol sensitivity analysis results.
 
@@ -457,6 +472,11 @@ def _plot_sobol_analysis(
     figsize: tuple | None
         Figure size as (width, height) in inches.If None, automatically calculated.
         Defaults to None.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The matplotlib figure containing the Sobol plots.
     """
     with plt.style.context("fast"):
         # prepare data
@@ -497,7 +517,7 @@ def _plot_sobol_analysis(
 
         plt.tight_layout()
 
-    return display_figure(fig)
+    return fig
 
 
 def _morris_results_to_df(
@@ -543,7 +563,7 @@ def _plot_morris_analysis(
     param_groups: dict[str, list[str]] | None = None,
     n_cols: int | None = None,
     figsize: tuple | None = None,
-):
+) -> matplotlib.figure.Figure:
     """
     Plot the Morris sensitivity analysis results.
 
@@ -558,6 +578,11 @@ def _plot_morris_analysis(
         otherwise the number of outputs.
     figsize: tuple, optional
         Figure size as (width, height) in inches. If None, automatically calculated.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The matplotlib figure containing the Morris plots.
     """
     with plt.style.context("fast"):
         unique_outputs = results["output"].unique()
@@ -660,7 +685,7 @@ def _plot_morris_analysis(
 
         plt.tight_layout()
 
-    return display_figure(fig)
+    return fig
 
 
 def _create_morris_plot(

--- a/autoemulate/core/sensitivity_analysis.py
+++ b/autoemulate/core/sensitivity_analysis.py
@@ -246,7 +246,7 @@ class SensitivityAnalysis(ConversionMixin):
     def plot_sobol(
         results: pd.DataFrame,
         index: str = "S1",
-        n_cols: int | None = None,
+        ncols: int | None = None,
         figsize: tuple | None = None,
         fname: str | None = None,
     ):
@@ -263,7 +263,7 @@ class SensitivityAnalysis(ConversionMixin):
             - "S2": second-order/interaction indices
             - "ST": total-order indices
             Defaults to "S1".
-        n_cols: int | None
+        ncols: int | None
             The number of columns in the plot. Defaults to 3 if there are 3 or
             more outputs, otherwise the number of outputs. Defaults to None.
         figsize: tuple | None
@@ -272,7 +272,7 @@ class SensitivityAnalysis(ConversionMixin):
         fname: str | None
             If provided, saves the figure to this file path. Defaults to None.
         """
-        fig = _plot_sobol_analysis(results, index, n_cols, figsize)
+        fig = _plot_sobol_analysis(results, index, ncols, figsize)
         if fname is None:
             return display_figure(fig)
         fig.savefig(fname, bbox_inches="tight")
@@ -282,7 +282,7 @@ class SensitivityAnalysis(ConversionMixin):
     def plot_morris(
         results: pd.DataFrame,
         param_groups: dict[str, list[str]] | None = None,
-        n_cols: int | None = None,
+        ncols: int | None = None,
         figsize: tuple | None = None,
         fname: str | None = None,
     ):
@@ -296,7 +296,7 @@ class SensitivityAnalysis(ConversionMixin):
         param_groups: dic[str, list[str]] | None
             Optional parameter groupings used to give all the same plot color
             of the form ({<group name> : [param1, ...], }).
-        n_cols: int, optional
+        ncols: int, optional
             The number of columns in the plot. Defaults to 3 if there are 3 or
             more outputs, otherwise the number of outputs.
         figsize: tuple, optional
@@ -304,7 +304,7 @@ class SensitivityAnalysis(ConversionMixin):
         fname: str | None
             If provided, saves the figure to this file path. Defaults to None.
         """
-        fig = _plot_morris_analysis(results, param_groups, n_cols, figsize)
+        fig = _plot_morris_analysis(results, param_groups, ncols, figsize)
         if fname is None:
             return display_figure(fig)
         fig.savefig(fname, bbox_inches="tight")
@@ -418,12 +418,12 @@ def _validate_input(results: pd.DataFrame, index: str):
     return results[results["index"].isin([index])]
 
 
-def _calculate_layout(n_outputs: int, n_cols: int | None = None):
+def _calculate_layout(n_outputs: int, ncols: int | None = None):
     """Calculate plot layout (n rows, n cols)."""
-    if n_cols is None:
-        n_cols = 3 if n_outputs >= 3 else n_outputs
-    n_rows = int(np.ceil(n_outputs / n_cols))
-    return n_rows, n_cols
+    if ncols is None:
+        ncols = 3 if n_outputs >= 3 else n_outputs
+    nrows = int(np.ceil(n_outputs / ncols))
+    return nrows, ncols
 
 
 def _create_bar_plot(ax: Axes, output_data: pd.DataFrame, output_name: str):
@@ -451,7 +451,7 @@ def _create_bar_plot(ax: Axes, output_data: pd.DataFrame, output_name: str):
 def _plot_sobol_analysis(
     results: pd.DataFrame,
     index: str = "S1",
-    n_cols: int | None = None,
+    ncols: int | None = None,
     figsize: tuple | None = None,
 ) -> matplotlib.figure.Figure:
     """
@@ -466,8 +466,8 @@ def _plot_sobol_analysis(
         - "S1": first-order indices
         - "S2": second-order/interaction indices
         - "ST": total-order indices
-    n_cols: int | None
-        The number of columns in the plot. If None, sets n_cols to 3 if there are 3 or
+    ncols: int | None
+        The number of columns in the plot. If None, sets ncols to 3 if there are 3 or
         more outputs, otherwise the number of outputs. Defaults to None.
     figsize: tuple | None
         Figure size as (width, height) in inches.If None, automatically calculated.
@@ -485,10 +485,10 @@ def _plot_sobol_analysis(
         n_outputs = len(unique_outputs)
 
         # layout
-        n_rows, n_cols = _calculate_layout(n_outputs, n_cols)
-        figsize = figsize or (4.5 * n_cols, 4 * n_rows)
+        nrows, ncols = _calculate_layout(n_outputs, ncols)
+        figsize = figsize or (4.5 * ncols, 4 * nrows)
 
-        fig, axes = plt.subplots(n_rows, n_cols, figsize=figsize)
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize)
         if isinstance(axes, np.ndarray):
             axes = axes.flatten()
         elif n_outputs == 1:
@@ -561,7 +561,7 @@ def _morris_results_to_df(
 def _plot_morris_analysis(
     results: pd.DataFrame,
     param_groups: dict[str, list[str]] | None = None,
-    n_cols: int | None = None,
+    ncols: int | None = None,
     figsize: tuple | None = None,
 ) -> matplotlib.figure.Figure:
     """
@@ -573,7 +573,7 @@ def _plot_morris_analysis(
         The results from morris_results_to_df.
     param_groups: dict, optional
         Dictionary mapping parameter names to groups for coloring.
-    n_cols: int, optional
+    ncols: int, optional
         The number of columns in the plot. Defaults to 3 if there are 3 or more outputs,
         otherwise the number of outputs.
     figsize: tuple, optional
@@ -589,10 +589,10 @@ def _plot_morris_analysis(
         n_outputs = len(unique_outputs)
 
         # layout - add space for legend
-        n_rows, n_cols = _calculate_layout(n_outputs, n_cols)
-        figsize = figsize or (4.5 * n_cols + 2, 4 * n_rows)  # Extra width for legend
+        nrows, ncols = _calculate_layout(n_outputs, ncols)
+        figsize = figsize or (4.5 * ncols + 2, 4 * nrows)  # Extra width for legend
 
-        fig, axes = plt.subplots(n_rows, n_cols, figsize=figsize)
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize)
         if isinstance(axes, np.ndarray):
             axes = axes.flatten()
         elif n_outputs == 1:

--- a/docs/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/tutorials/emulation/01_quickstart.ipynb
@@ -181,6 +181,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best.model.untransformed_model_name"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -200,7 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can quickly visualise the performance of this Emulator with a plot of its predictions against the simulator outputs for the heldout test data."
+    "We can quickly visualise the performance of this Emulator with a plot of its predictions against the simulator outputs for the heldout test data. We also save the plot to a file."
    ]
   },
   {
@@ -209,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ae.plot(best)"
+    "ae.plot(best, fname=\"best_model_plot.png\")"
    ]
   },
   {
@@ -300,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "autoemulate-py3.12",
    "language": "python",
    "name": "python3"
   },
@@ -314,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/tasks/01_emulation_sensitivity.ipynb
+++ b/docs/tutorials/tasks/01_emulation_sensitivity.ipynb
@@ -236,6 +236,24 @@
    "id": "14",
    "metadata": {},
    "source": [
+    "You can also save the plot directly to a file by passing the `fname` argument to the plotting function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sa.plot_sobol(sobol_df, index=\"ST\", figsize=figsize, fname=\"sobol_plot.png\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
     "Morris Interpretation:\n",
     "\n",
     "- High $\\mu^*$, Low $\\sigma$: Important parameter with linear/monotonic effects\n",
@@ -247,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +286,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "autoemulate-l4vGdsmY-py3.11",
+   "display_name": "autoemulate-py3.12",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Closes #732 

Plot saving option added to:
- model performance plot generated in AutoEmulate
- Sensitivity analysis plots (Sobol and Morris)

Everywhere else we either use external plotting libraries (e.g., arviz or pure matplotlib). If we want to explore adding saving functionality to the HistoryMatchingDashboard this should be handled as part of #509.

I did consider refactoring the code to create a plot filename similar to what we do when we save models but I felt that as a user I'd prefer to choose my own plot name directly. Happy for others to disagree.