### PR TITLE
Update `BayesianCalibation`to optionally include model variance and discrepancy

### DIFF
--- a/autoemulate/calibration/bayes.py
+++ b/autoemulate/calibration/bayes.py
@@ -199,22 +199,36 @@ class BayesianCalibration(TorchDeviceMixin):
             # - add model_discrepancy (variance)
             # - model variance (variance, if specified and provided by emulator)
 
-            # Get observation noise
+            # Get observation noise and ensure a 2D Tensor
             obs_noise = self.observation_noise[output]
-            if isinstance(self.observation_noise[output], float):
+            if isinstance(obs_noise, torch.Tensor) and obs_noise.ndim == 0:
+                obs_noise = obs_noise.reshape(1, 1).to(self.device)
+            elif isinstance(obs_noise, torch.Tensor) and obs_noise.ndim != 0:
+                msg = f"Observation noise tensor for output ({output}) must be scalar."
+                raise ValueError(msg)
+            elif isinstance(obs_noise, float):
                 obs_noise = torch.Tensor([[self.observation_noise[output]]])
+            else:
+                msg = "Observation noise must be a float or 0D tensor."
+                raise ValueError(msg)
             assert isinstance(obs_noise, TensorLike)
-            obs_noise = obs_noise.to(self.device) ** 2
 
-            # Combine variances additively, then take sqrt for final stddev
-            total_variance = obs_noise**2
-            total_variance += torch.full_like(
-                total_variance, self.model_discrepancy, device=self.device
+            # Construct variances, expand to model prediction shape, move to device
+            obs_noise_variance = obs_noise.pow(2).expand(*mean.shape).to(self.device)
+            model_discrepancy_variance = (
+                torch.full_like(obs_noise_variance, self.model_discrepancy)
+                .expand(*mean.shape)
+                .to(self.device)
             )
-            if self.model_variance and variance is not None:
-                total_variance += variance
 
-            scale = total_variance.sqrt()
+            # Combine variances (add model variance if required and available)
+            variance = (
+                obs_noise_variance + model_discrepancy_variance + variance
+                if self.model_variance and variance is not None
+                else obs_noise_variance + model_discrepancy_variance
+            )
+            # Take sqrt for final scale (stddev)
+            scale = variance.sqrt()
 
             if not predict:
                 with pyro.plate(f"data_{output}", self.n_observations):

--- a/autoemulate/calibration/history_matching.py
+++ b/autoemulate/calibration/history_matching.py
@@ -42,8 +42,9 @@ class HistoryMatching(TorchDeviceMixin):
         Parameters
         ----------
         observations: dict[str, tuple[float, float] | dict[str, float]
-            For each output variable, specifies observed [value, noise]. In case
-            of no uncertainty in observations, provides just the observed value.
+            For each output variable, specifies observed [value, noise] (with noise
+            specified as variances). In case of no uncertainty in observations, provides
+            just the observed value.
         threshold: float
             Implausibility threshold (query points with implausibility scores that
             exceed this value are ruled out). Defaults to 3, which is considered
@@ -84,13 +85,15 @@ class HistoryMatching(TorchDeviceMixin):
         Parameters
         ----------
         observations: dict[str, tuple[float, float] | dict[str, float]
-            For each output variable, specifies observed [value, noise]. In case
-            of no uncertainty in observations, provides just the observed value.
+            For each output variable, specifies observed [value, noise] (with noise
+            specified as variances). In case of no uncertainty in observations, provides
+            just the observed value.
 
         Returns
         -------
         tuple[TensorLike, TensorLike]
-            Tensors of observations and the associated noise (which can be 0).
+            Tensors of observations and the associated noise (which can be 0) specified
+            as variances.
         """
         values = torch.tensor(list(observations.values()), device=self.device)
 
@@ -292,8 +295,9 @@ class HistoryMatchingWorkflow(HistoryMatching):
         emulator: ProbabilisticEmulator
             A ProbabilisticEmulator pre-trained on `simulator` data.
         observations: dict[str, tuple[float, float] | dict[str, float]
-            For each output variable, specifies observed [value, noise]. In case
-            of no uncertainty in observations, provides just the observed value.
+            For each output variable, specifies observed [value, noise] (with noise
+            specified as variances). In case of no uncertainty in observations, provides
+            just the observed value.
         threshold: float
             Implausibility threshold (query points with implausibility scores that
             exceed this value are ruled out). Defaults to 3, which is considered

--- a/docs/tutorials/tasks/03_bayes_calibration.ipynb
+++ b/docs/tutorials/tasks/03_bayes_calibration.ipynb
@@ -141,7 +141,7 @@
    "outputs": [],
    "source": [
     "observations = {\"infection_rate\": observed_infection_rates}\n",
-    "observation_noise = 0.01\n",
+    "observation_noise = 0.0001\n",
     "\n",
     "bc = BayesianCalibration(\n",
     "    gp, \n",

--- a/tests/calibration/test_bayesian_calibration.py
+++ b/tests/calibration/test_bayesian_calibration.py
@@ -11,10 +11,19 @@ from autoemulate.simulations.projectile import (
 
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples"),
-    [(1, 1, 10), (10, 1, 10), (1, 2, 10), (10, 2, 10)],
+    ("n_obs", "n_chains", "n_samples", "model_variance"),
+    [
+        (1, 1, 10, False),
+        (10, 1, 10, False),
+        (1, 2, 10, False),
+        (10, 2, 10, False),
+        (1, 1, 10, True),
+        (10, 1, 10, True),
+        (1, 2, 10, True),
+        (10, 2, 10, True),
+    ],
 )
-def test_hmc_single_output(n_obs, n_chains, n_samples):
+def test_hmc_single_output(n_obs, n_chains, n_samples, model_variance):
     """
     Test HMC with single output.
     """
@@ -27,7 +36,9 @@ def test_hmc_single_output(n_obs, n_chains, n_samples):
 
     # pick the first n_obs sim outputs as observations
     observations = {"distance": y[:n_obs, 0]}
-    bc = BayesianCalibration(gp, sim.parameters_range, observations, 1.0)
+    bc = BayesianCalibration(
+        gp, sim.parameters_range, observations, 1.0, model_variance=model_variance
+    )
     assert bc.observation_noise == {"distance": 1.0}
 
     # check samples are generated
@@ -51,10 +62,19 @@ def test_hmc_single_output(n_obs, n_chains, n_samples):
 
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples"),
-    [(1, 1, 10), (10, 1, 10), (1, 2, 10), (10, 2, 10)],
+    ("n_obs", "n_chains", "n_samples", "model_variance"),
+    [
+        (1, 1, 10, False),
+        (10, 1, 10, False),
+        (1, 2, 10, False),
+        (10, 2, 10, False),
+        (1, 1, 10, True),
+        (10, 1, 10, True),
+        (1, 2, 10, True),
+        (10, 2, 10, True),
+    ],
 )
-def test_hmc_multiple_output(n_obs, n_chains, n_samples):
+def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_variance):
     """
     Test HMC with multiple outputs.
     """
@@ -70,7 +90,9 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples):
         "distance": y[:n_obs, 0],
         "impact_velocity": y[:n_obs, 1],
     }
-    bc = BayesianCalibration(gp, sim.parameters_range, observations, 1.0)
+    bc = BayesianCalibration(
+        gp, sim.parameters_range, observations, 1.0, model_variance=model_variance
+    )
     assert bc.observation_noise == {"distance": 1.0, "impact_velocity": 1.0}
 
     # check samples are generated

--- a/tests/calibration/test_bayesian_calibration.py
+++ b/tests/calibration/test_bayesian_calibration.py
@@ -11,7 +11,7 @@ from autoemulate.simulations.projectile import (
 
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples", "model_variance"),
+    ("n_obs", "n_chains", "n_samples", "model_uncertainty"),
     [
         (1, 1, 10, False),
         (10, 1, 10, False),
@@ -23,7 +23,7 @@ from autoemulate.simulations.projectile import (
         (10, 2, 10, True),
     ],
 )
-def test_hmc_single_output(n_obs, n_chains, n_samples, model_variance):
+def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     Test HMC with single output.
     """
@@ -37,7 +37,7 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_variance):
     # pick the first n_obs sim outputs as observations
     observations = {"distance": y[:n_obs, 0]}
     bc = BayesianCalibration(
-        gp, sim.parameters_range, observations, 1.0, model_variance=model_variance
+        gp, sim.parameters_range, observations, 1.0, model_uncertainty=model_uncertainty
     )
     assert bc.observation_noise == {"distance": 1.0}
 
@@ -62,7 +62,7 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_variance):
 
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples", "model_variance"),
+    ("n_obs", "n_chains", "n_samples", "model_uncertainty"),
     [
         (1, 1, 10, False),
         (10, 1, 10, False),
@@ -74,7 +74,7 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_variance):
         (10, 2, 10, True),
     ],
 )
-def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_variance):
+def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     Test HMC with multiple outputs.
     """
@@ -91,7 +91,7 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_variance):
         "impact_velocity": y[:n_obs, 1],
     }
     bc = BayesianCalibration(
-        gp, sim.parameters_range, observations, 1.0, model_variance=model_variance
+        gp, sim.parameters_range, observations, 1.0, model_uncertainty=model_uncertainty
     )
     assert bc.observation_noise == {"distance": 1.0, "impact_velocity": 1.0}
 

--- a/tests/learners/test_learners.py
+++ b/tests/learners/test_learners.py
@@ -26,7 +26,7 @@ def learners(
     assert isinstance(y_train, TensorLike)
     yield stream.Random(
         simulator=simulator,
-        emulator=GaussianProcess(x_train, y_train),
+        emulator=GaussianProcess(x_train, y_train, lr=0.001),
         x_train=x_train,
         y_train=y_train,
         p_query=0.25,
@@ -34,35 +34,35 @@ def learners(
     if not adaptive_only:
         yield stream.Distance(
             simulator=simulator,
-            emulator=GaussianProcess(x_train, y_train),
+            emulator=GaussianProcess(x_train, y_train, lr=0.001),
             x_train=x_train,
             y_train=y_train,
             threshold=0.5,
         )
         yield stream.A_Optimal(
             simulator=simulator,
-            emulator=GaussianProcess(x_train, y_train),
+            emulator=GaussianProcess(x_train, y_train, lr=0.001),
             x_train=x_train,
             y_train=y_train,
             threshold=1.0,
         )
         yield stream.D_Optimal(
             simulator=simulator,
-            emulator=GaussianProcess(x_train, y_train),
+            emulator=GaussianProcess(x_train, y_train, lr=0.001),
             x_train=x_train,
             y_train=y_train,
             threshold=-4.2,
         )
         yield stream.E_Optimal(
             simulator=simulator,
-            emulator=GaussianProcess(x_train, y_train),
+            emulator=GaussianProcess(x_train, y_train, lr=0.001),
             x_train=x_train,
             y_train=y_train,
             threshold=1.0,
         )
     yield stream.Adaptive_Distance(
         simulator=simulator,
-        emulator=GaussianProcess(x_train, y_train),
+        emulator=GaussianProcess(x_train, y_train, lr=0.001),
         x_train=x_train,
         y_train=y_train,
         threshold=0.5,
@@ -77,7 +77,7 @@ def learners(
     )
     yield stream.Adaptive_A_Optimal(
         simulator=simulator,
-        emulator=GaussianProcess(x_train, y_train),
+        emulator=GaussianProcess(x_train, y_train, lr=0.001),
         x_train=x_train,
         y_train=y_train,
         threshold=1e-1,
@@ -92,7 +92,7 @@ def learners(
     )
     yield stream.Adaptive_D_Optimal(
         simulator=simulator,
-        emulator=GaussianProcess(x_train, y_train),
+        emulator=GaussianProcess(x_train, y_train, lr=0.001),
         x_train=x_train,
         y_train=y_train,
         threshold=-4.0,
@@ -107,7 +107,7 @@ def learners(
     )
     yield stream.Adaptive_E_Optimal(
         simulator=simulator,
-        emulator=GaussianProcess(x_train, y_train),
+        emulator=GaussianProcess(x_train, y_train, lr=0.001),
         x_train=x_train,
         y_train=y_train,
         threshold=0.75 if isinstance(simulator, Sin) else 1000,


### PR DESCRIPTION
Closes #760.

This PR:
- Adds API for model variance and discrepancy
- Updates likelihood calculation to (optionally) include model variance and discrepancy