### PR TITLE
Set random seeds in Bayes tutorial for reproducibility

### DIFF
--- a/docs/tutorials/tasks/03_bayes_calibration.ipynb
+++ b/docs/tutorials/tasks/03_bayes_calibration.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ae = AutoEmulate(x, y, models=[GaussianProcess], log_level=\"error\", random_seed=42)"
+    "ae = AutoEmulate(x, y, models=[GaussianProcess], log_level=\"error\", random_seed=123)"
    ]
   },
   {
@@ -235,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = az.plot_trace(az_data)"
+    "_ = az.plot_trace(az_data, figsize=(20, 8))"
    ]
   },
   {


### PR DESCRIPTION
I added random seeds to the simulator sampling and emulator fitting to hopefully get consistent results in the Bayesian calibration tutorial. 