### PR TITLE
Update Simulator.forward_batch to always return x,y

### DIFF
--- a/autoemulate/calibration/history_matching.py
+++ b/autoemulate/calibration/history_matching.py
@@ -421,7 +421,7 @@ class HistoryMatchingWorkflow(HistoryMatching):
             Tensors of succesfully simulated input parameters and predictions.
         """
         # if simulation fails, returned y and x have fewer rows than input x
-        y, x = self.simulator.forward_batch_skip_failures(x)
+        y, x = self.simulator.forward_batch(x)
         y = y.to(self.device)
         x = x.to(self.device)
 

--- a/autoemulate/simulations/base.py
+++ b/autoemulate/simulations/base.py
@@ -253,15 +253,18 @@ class Simulator(ABC, ValidationMixin):
             if not allow_failures:
                 self.logger.error("Error occurred during simulation: %s", e)
                 raise
+            self.logger.warning("Simulation failed with error %s. Returning None", e)
         return None
 
     def forward_batch(
         self, x: TensorLike, allow_failures: bool = True
     ) -> tuple[TensorLike, TensorLike]:
-        """Run multiple simulations, skipping any that fail.
+        """
+        Run multiple simulations.
 
-        Failed simulations are skipped, and only successful results are returned
-        along with their corresponding input parameters.
+        If allow_failures is False, failed simulations will raise an error.
+        Otherwise, failed simulations are skipped, and only successful results
+        are returned along with their corresponding input parameters.
 
         Parameters
         ----------

--- a/autoemulate/simulations/base.py
+++ b/autoemulate/simulations/base.py
@@ -240,38 +240,6 @@ class Simulator(ABC, ValidationMixin):
             return y
         return None
 
-    def forward_batch_strict(self, x: TensorLike) -> TensorLike:
-        """Run multiple simulations with different parameters.
-
-        For infallible simulators that always succeed.
-        If your simulator might fail and you don't want that to raise an error,
-        use `forward_batch()` instead.
-
-        Parameters
-        ----------
-        x: TensorLike
-            Tensor of input parameters to make predictions for.
-
-        Returns
-        -------
-        TensorLike
-            Tensor of simulation results of shape (n_batch, self.out_dim).
-
-        Raises
-        ------
-        RuntimeError
-            If the number of simulations does not match the input.
-            Use `forward_batch()` to handle failures.
-        """
-        results, x_valid = self.forward_batch(x)
-
-        # Raise an error if the number of simulations does not match the input
-        if x.shape[0] != x_valid.shape[0]:
-            msg = "Some simulations failed. Use forward_batch() to handle failures."
-            raise RuntimeError(msg)
-
-        return results
-
     def forward_batch(self, x: TensorLike) -> tuple[TensorLike, TensorLike]:
         """Run multiple simulations, skipping any that fail.
 

--- a/autoemulate/simulations/base.py
+++ b/autoemulate/simulations/base.py
@@ -219,7 +219,7 @@ class Simulator(ABC, ValidationMixin):
         TensorLike | None
             Simulated output tensor. Shape = (1, self.out_dim).
             For example, if the simulator outputs two simulated variables,
-            then the shape would be (1, 2). None if the simulation fails.
+            then the shape would be (1, 2).
         """
 
     def forward(self, x: TensorLike, allow_failures: bool = True) -> TensorLike | None:
@@ -227,6 +227,8 @@ class Simulator(ABC, ValidationMixin):
         Generate samples from input data using the simulator.
 
         Combines the abstract method `_forward` with some validation checks.
+        If there is a failure during the forward pass of the simulation,
+        the error is logged and None is returned.
 
         Parameters
         ----------

--- a/autoemulate/simulations/base.py
+++ b/autoemulate/simulations/base.py
@@ -243,7 +243,6 @@ class Simulator(ABC, ValidationMixin):
     def forward_batch(self, x: TensorLike) -> tuple[TensorLike, TensorLike]:
         """Run multiple simulations, skipping any that fail.
 
-        For simulators where for some inputs the simulation can fail.
         Failed simulations are skipped, and only successful results are returned
         along with their corresponding input parameters.
 

--- a/autoemulate/simulations/base.py
+++ b/autoemulate/simulations/base.py
@@ -240,11 +240,12 @@ class Simulator(ABC, ValidationMixin):
             return y
         return None
 
-    def forward_batch(self, x: TensorLike) -> TensorLike:
+    def forward_batch_strict(self, x: TensorLike) -> TensorLike:
         """Run multiple simulations with different parameters.
 
         For infallible simulators that always succeed.
-        If your simulator might fail, use `forward_batch_skip_failures()` instead.
+        If your simulator might fail and you don't want that to raise an error,
+        use `forward_batch()` instead.
 
         Parameters
         ----------
@@ -260,23 +261,18 @@ class Simulator(ABC, ValidationMixin):
         ------
         RuntimeError
             If the number of simulations does not match the input.
-            Use `forward_batch_skip_failures()` to handle failures.
+            Use `forward_batch()` to handle failures.
         """
-        results, x_valid = self.forward_batch_skip_failures(x)
+        results, x_valid = self.forward_batch(x)
 
         # Raise an error if the number of simulations does not match the input
         if x.shape[0] != x_valid.shape[0]:
-            msg = (
-                "Some simulations failed. Use forward_batch_skip_failures() to handle "
-                "failures."
-            )
+            msg = "Some simulations failed. Use forward_batch() to handle failures."
             raise RuntimeError(msg)
 
         return results
 
-    def forward_batch_skip_failures(
-        self, x: TensorLike
-    ) -> tuple[TensorLike, TensorLike]:
+    def forward_batch(self, x: TensorLike) -> tuple[TensorLike, TensorLike]:
         """Run multiple simulations, skipping any that fail.
 
         For simulators where for some inputs the simulation can fail.

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -89,7 +89,8 @@ def main(  # noqa: PLR0913
         simulator: Simulator = SIMULATOR_REGISTRY[simulator_str]()
         max_samples = max(n_samples_list)
         x_all = simulator.sample_inputs(max_samples, random_seed=seed).to(torch.float32)
-        y_all = simulator.forward_batch_strict(x_all).to(torch.float32)
+        y_all, _ = simulator.forward_batch(x_all)
+        y_all = y_all.to(torch.float32)
 
         params = list(itertools.product(n_samples_list, n_iter_list, n_splits_list))
         np.random.seed(seed)

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -89,7 +89,7 @@ def main(  # noqa: PLR0913
         simulator: Simulator = SIMULATOR_REGISTRY[simulator_str]()
         max_samples = max(n_samples_list)
         x_all = simulator.sample_inputs(max_samples, random_seed=seed).to(torch.float32)
-        y_all = simulator.forward_batch(x_all).to(torch.float32)
+        y_all = simulator.forward_batch_strict(x_all).to(torch.float32)
 
         params = list(itertools.product(n_samples_list, n_iter_list, n_splits_list))
         np.random.seed(seed)

--- a/docs/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/tutorials/emulation/01_quickstart.ipynb
@@ -52,7 +52,7 @@
     "projectile = Projectile(log_level=\"error\")\n",
     "n_samples = 500\n",
     "x = projectile.sample_inputs(n_samples).float()\n",
-    "y = projectile.forward_batch(x).float()\n",
+    "y, _ = projectile.forward_batch(x).float()\n",
     "\n",
     "x.shape, y.shape"
    ]

--- a/docs/tutorials/emulation/01_quickstart.ipynb
+++ b/docs/tutorials/emulation/01_quickstart.ipynb
@@ -52,7 +52,8 @@
     "projectile = Projectile(log_level=\"error\")\n",
     "n_samples = 500\n",
     "x = projectile.sample_inputs(n_samples).float()\n",
-    "y, _ = projectile.forward_batch(x).float()\n",
+    "y, _ = projectile.forward_batch(x)\n",
+    "y = y.float()\n",
     "\n",
     "x.shape, y.shape"
    ]

--- a/docs/tutorials/emulation/02_dim_reduction.ipynb
+++ b/docs/tutorials/emulation/02_dim_reduction.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "    # Run the simulator to generate data \n",
     "    # Simulator returns flattened species U and V\n",
-    "    UV = sim.forward_batch(X)\n",
+    "    UV, _ = sim.forward_batch(X)\n",
     "\n",
     "    # Let's consider as output the concentration of species U\n",
     "    m = int(UV.shape[1] / 2)\n",
@@ -285,7 +285,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "autoemulate",
    "language": "python",
    "name": "python3"
   },
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/simulator/01_custom_simulations.ipynb
+++ b/docs/tutorials/simulator/01_custom_simulations.ipynb
@@ -23,8 +23,7 @@
     "- `output_variables`: A parameter set at class initiation. A list of strings that are the names of the outputs that the simulator will return.\n",
     "- `_forward`: An abstract method that must be implemented by the user. This method will define a single forward pass of the simulation, taking in the input parameters and returning the output variables. *There are some important rules for this method:*\n",
     "  - The input to the method must be a tensor of shape `(1, n)` where `n` is the number of input parameters.\n",
-    "  - The output of th method must be a tensor of shape `(1, m)` where `m` is the number of output variables. \n",
-    "  - If the simulation fails, it must output `None`.\n"
+    "  - The output of th method must be a tensor of shape `(1, m)` where `m` is the number of output variables. \n"
    ]
   },
   {
@@ -246,7 +245,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "autoemulate-g498s5yu-py3.12",
    "language": "python",
    "name": "python3"
   },
@@ -260,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/simulator/01_custom_simulations.ipynb
+++ b/docs/tutorials/simulator/01_custom_simulations.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "multiple_output = projectile_simulator.forward_batch(input_samples)\n",
+    "multiple_output, _ = projectile_simulator.forward_batch(input_samples)\n",
     "\n",
     "print(\"Multiple output: \", multiple_output)\n",
     "print(\"Multiple output shape: \", multiple_output.shape)"
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "inputs = projectile_simulator.sample_inputs(10_000)\n",
-    "outputs = projectile_simulator.forward_batch(inputs)"
+    "outputs = projectile_simulator.forward_batch_strict(inputs)"
    ]
   },
   {

--- a/docs/tutorials/simulator/01_custom_simulations.ipynb
+++ b/docs/tutorials/simulator/01_custom_simulations.ipynb
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "inputs = projectile_simulator.sample_inputs(10_000)\n",
-    "outputs = projectile_simulator.forward_batch_strict(inputs)"
+    "outputs, _ = projectile_simulator.forward_batch(inputs)"
    ]
   },
   {

--- a/docs/tutorials/simulator/02_active_learning.ipynb
+++ b/docs/tutorials/simulator/02_active_learning.ipynb
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y = simulator.forward_batch(x)\n",
+    "y, _ = simulator.forward_batch(x)\n",
     "print(y)"
    ]
   },
@@ -163,7 +163,7 @@
    "outputs": [],
    "source": [
     "x = simulator.sample_inputs(1000)\n",
-    "y = simulator.forward_batch(x)\n",
+    "y, _ = simulator.forward_batch(x)\n",
     "plt.scatter(x, y, marker='.', c='k')\n",
     "plt.show()"
    ]
@@ -198,7 +198,7 @@
     "# Train emulator\n",
     "simulator = Sin()\n",
     "x_train = simulator.sample_inputs(25).sort(dim=0).values\n",
-    "y_train = simulator.forward_batch(x_train)\n",
+    "y_train, _ = simulator.forward_batch(x_train)\n",
     "\n",
     "def make_gp(x_train, y_train, lr=5e-2):\n",
     "    return GaussianProcess(x_train, y_train, lr=lr, posterior_predictive=True)\n",
@@ -210,7 +210,7 @@
     "x_test = simulator.sample_inputs(1000).sort(dim=0).values\n",
     "y_mean, var = emulator.predict_mean_and_variance(x_test)\n",
     "y_std = var.sqrt()\n",
-    "y_true = simulator.forward_batch(x_test)\n",
+    "y_true, _ = simulator.forward_batch(x_test)\n",
     "\n",
     "# Plot\n",
     "plt.plot(x_test.flatten(), y_true.flatten(), label='Simulator', alpha=0.5, c='k')\n",
@@ -258,7 +258,7 @@
     "simulator = Sin()\n",
     "\n",
     "x_train = simulator.sample_inputs(5)\n",
-    "y_train = simulator.forward_batch(x_train)\n",
+    "y_train, _ = simulator.forward_batch(x_train)\n",
     "emulator = make_gp(x_train, y_train, 0.01)\n",
     "\n",
     "# Learner itself!\n",
@@ -456,7 +456,7 @@
    "source": [
     "def learners(*, simulator: Simulator, n_initial_samples: int, adaptive_only: bool, lr=2e-2) -> Iterable:\n",
     "    x_train = simulator.sample_inputs(n_initial_samples)\n",
-    "    y_train = simulator.forward_batch(x_train)\n",
+    "    y_train, _ = simulator.forward_batch(x_train)\n",
     "\n",
     "    yield stream.Random(\n",
     "        simulator=simulator, emulator=make_gp(x_train, y_train, lr=lr),\n",
@@ -718,7 +718,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "autoemulate",
    "language": "python",
    "name": "python3"
   },

--- a/docs/tutorials/simulator/03_history_matching.ipynb
+++ b/docs/tutorials/simulator/03_history_matching.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "simulator = Epidemic(log_level=\"error\")\n",
     "x = simulator.sample_inputs(500, random_seed=random_seed)\n",
-    "y = simulator.forward_batch(x)"
+    "y, _ = simulator.forward_batch(x)"
    ]
   },
   {
@@ -224,7 +224,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "autoemulate",
    "language": "python",
    "name": "python3"
   },

--- a/docs/tutorials/tasks/01_emulation_sensitivity.ipynb
+++ b/docs/tutorials/tasks/01_emulation_sensitivity.ipynb
@@ -132,7 +132,7 @@
    "outputs": [],
    "source": [
     "x = simulator.sample_inputs(100)\n",
-    "y = simulator.forward_batch(x)"
+    "y, _ = simulator.forward_batch(x)"
    ]
   },
   {
@@ -286,7 +286,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "autoemulate-py3.12",
+   "display_name": "autoemulate",
    "language": "python",
    "name": "python3"
   },

--- a/docs/tutorials/tasks/02_history_matching.ipynb
+++ b/docs/tutorials/tasks/02_history_matching.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "simulator = Projectile(log_level=\"error\")\n",
     "x = simulator.sample_inputs(1000)\n",
-    "y = simulator.forward_batch(x)"
+    "y, _ = simulator.forward_batch(x)"
    ]
   },
   {

--- a/docs/tutorials/tasks/03_bayes_calibration.ipynb
+++ b/docs/tutorials/tasks/03_bayes_calibration.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "simulator = Epidemic(log_level=\"error\")\n",
     "x = simulator.sample_inputs(100, random_seed=42)\n",
-    "y = simulator.forward_batch(x)"
+    "y, _ = simulator.forward_batch(x)"
    ]
   },
   {

--- a/tests/calibration/test_bayesian_calibration.py
+++ b/tests/calibration/test_bayesian_calibration.py
@@ -24,7 +24,7 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     sim = Projectile()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch_strict(x)
+    y, _ = sim.forward_batch(x)
     assert isinstance(y, TensorLike)
     gp = GaussianProcess(x, y)
     gp.fit(x, y)
@@ -75,7 +75,7 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     sim = ProjectileMultioutput()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch_strict(x)
+    y, _ = sim.forward_batch(x)
     assert isinstance(y, TensorLike)
     gp = GaussianProcess(x, y)
     gp.fit(x, y)

--- a/tests/calibration/test_bayesian_calibration.py
+++ b/tests/calibration/test_bayesian_calibration.py
@@ -1,13 +1,8 @@
 import pytest
 from autoemulate.calibration.bayes import BayesianCalibration
 from autoemulate.core.types import TensorLike
-from autoemulate.emulators.gaussian_process.exact import (
-    GaussianProcess,
-)
-from autoemulate.simulations.projectile import (
-    Projectile,
-    ProjectileMultioutput,
-)
+from autoemulate.emulators.gaussian_process.exact import GaussianProcess
+from autoemulate.simulations.projectile import Projectile, ProjectileMultioutput
 
 
 @pytest.mark.parametrize(
@@ -29,7 +24,7 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     sim = Projectile()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch(x)
+    y = sim.forward_batch_strict(x)
     assert isinstance(y, TensorLike)
     gp = GaussianProcess(x, y)
     gp.fit(x, y)
@@ -80,7 +75,7 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
     """
     sim = ProjectileMultioutput()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch(x)
+    y = sim.forward_batch_strict(x)
     assert isinstance(y, TensorLike)
     gp = GaussianProcess(x, y)
     gp.fit(x, y)

--- a/tests/calibration/test_history_matching.py
+++ b/tests/calibration/test_history_matching.py
@@ -99,7 +99,7 @@ def test_run(device):
 
     simulator = Epidemic()
     x = simulator.sample_inputs(10)
-    y = simulator.forward_batch_strict(x)
+    y, _ = simulator.forward_batch(x)
     assert isinstance(y, TensorLike)
 
     # Run history matching
@@ -138,7 +138,7 @@ def test_run_max_tries():
     """Run history matching with observations that return no NROY params."""
     simulator = Epidemic()
     x = simulator.sample_inputs(10)
-    y = simulator.forward_batch_strict(x)
+    y, _ = simulator.forward_batch(x)
     assert isinstance(y, TensorLike)
 
     # Run history matching

--- a/tests/calibration/test_history_matching.py
+++ b/tests/calibration/test_history_matching.py
@@ -99,7 +99,7 @@ def test_run(device):
 
     simulator = Epidemic()
     x = simulator.sample_inputs(10)
-    y = simulator.forward_batch(x)
+    y = simulator.forward_batch_strict(x)
     assert isinstance(y, TensorLike)
 
     # Run history matching
@@ -138,7 +138,7 @@ def test_run_max_tries():
     """Run history matching with observations that return no NROY params."""
     simulator = Epidemic()
     x = simulator.sample_inputs(10)
-    y = simulator.forward_batch(x)
+    y = simulator.forward_batch_strict(x)
     assert isinstance(y, TensorLike)
 
     # Run history matching

--- a/tests/core/test_sensitivity_analysis.py
+++ b/tests/core/test_sensitivity_analysis.py
@@ -11,7 +11,7 @@ from autoemulate.simulations.projectile import Projectile, ProjectileMultioutput
 def xy_1d():
     sim = Projectile()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch_strict(x)
+    y, _ = sim.forward_batch(x)
     return x, y
 
 
@@ -19,7 +19,7 @@ def xy_1d():
 def xy_2d():
     sim = ProjectileMultioutput()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch_strict(x)
+    y, _ = sim.forward_batch(x)
     return x, y
 
 

--- a/tests/core/test_sensitivity_analysis.py
+++ b/tests/core/test_sensitivity_analysis.py
@@ -4,17 +4,14 @@ import pytest
 import torch
 from autoemulate.core.sensitivity_analysis import SensitivityAnalysis
 from autoemulate.emulators.random_forest import RandomForest
-from autoemulate.simulations.projectile import (
-    Projectile,
-    ProjectileMultioutput,
-)
+from autoemulate.simulations.projectile import Projectile, ProjectileMultioutput
 
 
 @pytest.fixture
 def xy_1d():
     sim = Projectile()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch(x)
+    y = sim.forward_batch_strict(x)
     return x, y
 
 
@@ -22,7 +19,7 @@ def xy_1d():
 def xy_2d():
     sim = ProjectileMultioutput()
     x = sim.sample_inputs(100)
-    y = sim.forward_batch(x)
+    y = sim.forward_batch_strict(x)
     return x, y
 
 

--- a/tests/learners/test_learners.py
+++ b/tests/learners/test_learners.py
@@ -20,7 +20,7 @@ def learners(
     *, simulator: Simulator, n_initial_samples: int, adaptive_only: bool
 ) -> Iterable:
     x_train = simulator.sample_inputs(n_initial_samples)
-    y_train = simulator.forward_batch_strict(x_train)
+    y_train, _ = simulator.forward_batch(x_train)
     assert isinstance(y_train, TensorLike)
     yield stream.Random(
         simulator=simulator,

--- a/tests/learners/test_learners.py
+++ b/tests/learners/test_learners.py
@@ -3,9 +3,7 @@ from collections.abc import Iterable
 import numpy as np
 import torch
 from autoemulate.core.types import TensorLike
-from autoemulate.emulators.gaussian_process.exact import (
-    GaussianProcess,
-)
+from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.learners import stream
 from autoemulate.simulations.base import Simulator
 from autoemulate.simulations.projectile import ProjectileMultioutput
@@ -22,7 +20,7 @@ def learners(
     *, simulator: Simulator, n_initial_samples: int, adaptive_only: bool
 ) -> Iterable:
     x_train = simulator.sample_inputs(n_initial_samples)
-    y_train = simulator.forward_batch(x_train)
+    y_train = simulator.forward_batch_strict(x_train)
     assert isinstance(y_train, TensorLike)
     yield stream.Random(
         simulator=simulator,

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -104,7 +104,7 @@ def test_forward(mock_simulator):
     assert output[0, 1] == pytest.approx(expected_sum * 2)
 
 
-def test_forward_batch(mock_simulator):
+def test_forward_batch_strict(mock_simulator):
     """Test that forward_batch method processes multiple samples correctly"""
     # Create test batch
     n_samples = 3
@@ -113,7 +113,7 @@ def test_forward_batch(mock_simulator):
     )
 
     # Process batch
-    results = mock_simulator.forward_batch(batch)
+    results = mock_simulator.forward_batch_strict(batch)
 
     # Check shape
     assert results.shape == (n_samples, len(mock_simulator._output_names))
@@ -188,7 +188,7 @@ def test_handle_simulation_failure():
 
     # This should process all samples without errors
     # We're just verifying it doesn't crash
-    results, valid_x = simulator.forward_batch_skip_failures(batch)
+    results, valid_x = simulator.forward_batch(batch)
     assert isinstance(results, TensorLike)
 
     # Verify results shape

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -104,27 +104,6 @@ def test_forward(mock_simulator):
     assert output[0, 1] == pytest.approx(expected_sum * 2)
 
 
-def test_forward_batch_strict(mock_simulator):
-    """Test that forward_batch method processes multiple samples correctly"""
-    # Create test batch
-    n_samples = 3
-    batch = torch.tensor(
-        [[0.5, 0.0, 7.5], [0.2, 0.3, 6.0], [0.8, -0.5, 9.0]], dtype=torch.float32
-    )
-
-    # Process batch
-    results = mock_simulator.forward_batch_strict(batch)
-
-    # Check shape
-    assert results.shape == (n_samples, len(mock_simulator._output_names))
-
-    # Check values for each sample
-    for i in range(n_samples):
-        expected_sum = sum(batch[i].tolist())
-        assert results[i, 0] == pytest.approx(expected_sum * 1)
-        assert results[i, 1] == pytest.approx(expected_sum * 2)
-
-
 def test_get_parameter_idx(mock_simulator):
     """Test that get_parameter_idx returns correct indices"""
     assert mock_simulator.get_parameter_idx("param1") == 0

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -226,3 +226,101 @@ def test_sample(method):
     assert torch.all(samples[:, 1] <= 100.0)
     assert torch.all(samples[:, 1] <= 100.0)
     assert torch.all(samples[:, 2] == 1000.0)
+
+
+class FailingSimulator(Simulator):
+    """A simulator that fails on specific input values"""
+
+    def __init__(
+        self,
+        parameters_range: dict[str, tuple[float, float]],
+        output_names: list[str],
+        failure_threshold: float = 0.5,
+    ):
+        super().__init__(parameters_range, output_names)
+        self.failure_threshold = failure_threshold
+
+    def _forward(self, x: TensorLike) -> TensorLike | None:
+        # Fail if first parameter exceeds the threshold
+        if x[0, 0] > self.failure_threshold:
+            raise RuntimeError(
+                f"Simulation failed: parameter {x[0, 0]} exceeds "
+                f"threshold {self.failure_threshold}"
+            )
+
+        # Create outputs (simple sum with multiplier for each output)
+        outputs = []
+        for i, _ in enumerate(self.output_names):
+            output = torch.sum(x, dim=1) * (i + 1)
+            outputs.append(output.view(-1, 1))
+
+        return torch.cat(outputs, dim=1)
+
+
+def test_forward_allow_failures():
+    """Test allow_failures parameter in forward method"""
+    # Create simulator
+    params = {"param1": (0.0, 1.0), "param2": (0.0, 1.0)}
+    simulator = FailingSimulator(params, ["var1"])
+
+    # Input that will succeed
+    success_input = torch.tensor([[0.4, 0.5]], dtype=torch.float32)
+
+    # Input that will fail (param1 > 0.5)
+    failure_input = torch.tensor([[0.7, 0.5]], dtype=torch.float32)
+
+    # With allow_failures=True (default), should return None on failure
+    assert simulator.forward(success_input) is not None
+    assert simulator.forward(failure_input) is None
+
+    # With allow_failures=False, should raise an exception on failure
+    assert simulator.forward(success_input, allow_failures=False) is not None
+    with pytest.raises(RuntimeError, match="Simulation failed"):
+        simulator.forward(failure_input, allow_failures=False)
+
+
+def test_forward_batch_allow_failures():
+    """
+    Test allow_failures parameter in forward_batch method
+    """
+    # Create simulator
+    params = {"param1": (0.0, 1.0), "param2": (0.0, 1.0)}
+    simulator = FailingSimulator(params, ["var1"])
+
+    # Create a batch with mix of inputs that will succeed and fail
+    mixed_batch = torch.tensor(
+        [
+            [0.3, 0.5],  # Will succeed
+            [0.6, 0.5],  # Will fail (param1 > 0.5)
+            [0.2, 0.5],  # Will succeed
+            [0.8, 0.5],  # Will fail (param1 > 0.5)
+        ],
+        dtype=torch.float32,
+    )
+
+    # With allow_failures=True (default),
+    # should skip failures and return only successful results
+    # and filter out failed simulations
+    results, valid_inputs = simulator.forward_batch(mixed_batch)
+    assert len(results) == 2  # Only 2 successful simulations
+    assert len(valid_inputs) == 2
+    # Check which indices were successful (should be indices 0 and 2)
+    assert torch.allclose(valid_inputs[0], mixed_batch[0])
+    assert torch.allclose(valid_inputs[1], mixed_batch[2])
+
+    # With allow_failures=False, should raise an exception on first failure
+    with pytest.raises(RuntimeError, match="Simulation failed"):
+        simulator.forward_batch(mixed_batch, allow_failures=False)
+
+    # Test with batch that has no failures
+    success_batch = torch.tensor(
+        [
+            [0.3, 0.5],  # Will succeed
+            [0.2, 0.5],  # Will succeed
+        ],
+        dtype=torch.float32,
+    )
+    results, valid_inputs = simulator.forward_batch(success_batch, allow_failures=False)
+    assert len(results) == 2  # All simulations successful
+    assert len(valid_inputs) == 2
+    assert torch.allclose(valid_inputs, success_batch)


### PR DESCRIPTION
Closes #711 

This PR renames `forward_batch_skip_failures` -> `forward_batch` and removes the original `forward_batch` method.
