### PR TITLE
Don't tune if user passes model_params

### DIFF
--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -159,6 +159,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         self.n_bootstraps = n_bootstraps
         self.max_retries = max_retries
         self.model_params = model_params or {}
+        self.model_tuning = model_params is None
         self.transformed_emulator_params = transformed_emulator_params or {}
 
         # Set up logger and ModelSerialiser for saving models
@@ -357,7 +358,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 attempt + 1,
                                 self.max_retries,
                             )
-                            if not self.model_params:
+                            if self.model_tuning:
                                 self.logger.debug(
                                     'Running tuner for model "%s"',
                                     model_cls.__name__,

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -169,6 +169,9 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         self.logger, self.progress_bar = get_configured_logger(log_level)
         self.model_serialiser = ModelSerialiser(self.logger)
 
+        if self.model_tuning and self.model_params:
+            self.logger.debug("Not model tuning as model_params were provided.")
+
         # Run compare
         self.compare()
 

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -361,7 +361,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 attempt + 1,
                                 self.max_retries,
                             )
-                            if self.model_tuning:
+                            if self.model_tuning and not self.model_params:
                                 self.logger.debug(
                                     'Running tuner for model "%s"',
                                     model_cls.__name__,

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -170,7 +170,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         self.model_serialiser = ModelSerialiser(self.logger)
 
         if self.model_tuning and self.model_params:
-            self.logger.debug("Not model tuning as model_params were provided.")
+            self.logger.warning("Not model tuning as model_params were provided.")
 
         # Run compare
         self.compare()

--- a/docs/tutorials/emulation/02_dim_reduction.ipynb
+++ b/docs/tutorials/emulation/02_dim_reduction.ipynb
@@ -174,7 +174,6 @@
     "    # fewer bootstraps to reduce computation time, though more uncertainty on test score\n",
     "    n_bootstraps=20,\n",
     "    log_level=\"error\",\n",
-    "    model_tuning=False,\n",
     "    model_params={\"posterior_predictive\": True},\n",
     "    transformed_emulator_params={\"n_samples\": 1000}\n",
     ")\n"
@@ -299,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/simulator/03_history_matching.ipynb
+++ b/docs/tutorials/simulator/03_history_matching.ipynb
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the purposes of this tutorial, we will restrict the model choice to `GaussianProcess`."
+    "For the purposes of this tutorial, we will restrict the model choice to `GaussianProcess` with default parameters."
    ]
   },
   {
@@ -80,7 +80,7 @@
     "    x,\n",
     "    y,\n",
     "    models=[GaussianProcess],\n",
-    "    model_tuning=False,\n",
+    "    model_params={},\n",
     "    log_level=\"error\",\n",
     "    random_seed=random_seed\n",
     ")"

--- a/tests/core/test_compare.py
+++ b/tests/core/test_compare.py
@@ -64,13 +64,11 @@ def test_get_model_subset():
     pytorch_subset = set(PYTORCH_EMULATORS)
     probabilistic_subset = {e for e in ALL_EMULATORS if e.supports_uq}
 
-    ae = AutoEmulate(x, y, only_pytorch=True, model_tuning=False)
+    ae = AutoEmulate(x, y, only_pytorch=True, model_params={})
     assert set(ae.models) == pytorch_subset
 
-    ae = AutoEmulate(x, y, only_probabilistic=True, model_tuning=False)
+    ae = AutoEmulate(x, y, only_probabilistic=True, model_params={})
     assert set(ae.models) == probabilistic_subset
 
-    ae = AutoEmulate(
-        x, y, only_pytorch=True, only_probabilistic=True, model_tuning=False
-    )
+    ae = AutoEmulate(x, y, only_pytorch=True, only_probabilistic=True, model_params={})
     assert set(ae.models) == pytorch_subset.intersection(probabilistic_subset)


### PR DESCRIPTION
Currently, if the user passes `model_params` but does not specify `model_tuning=False` then the passed params get ignored. This can lead to user error (this has happened). It feels that the expected behaviour should be that in that case no tuning happens. This PR proposes this change. An alternative would be to raise an error or at least a warning, that would also be a reasonable option.