### PR TITLE
Improve emulator re-initialisation

### DIFF
--- a/autoemulate/emulators/ensemble.py
+++ b/autoemulate/emulators/ensemble.py
@@ -4,17 +4,8 @@ import torch
 from torch import Tensor
 
 from autoemulate.core.device import TorchDeviceMixin
-from autoemulate.core.types import (
-    DeviceLike,
-    GaussianLike,
-    TensorLike,
-    TuneParams,
-)
-from autoemulate.emulators.base import (
-    DropoutTorchBackend,
-    Emulator,
-    GaussianEmulator,
-)
+from autoemulate.core.types import DeviceLike, GaussianLike, TensorLike, TuneParams
+from autoemulate.emulators.base import DropoutTorchBackend, Emulator, GaussianEmulator
 from autoemulate.emulators.nn.mlp import MLP
 from autoemulate.transforms.standardize import StandardizeTransform
 from autoemulate.transforms.utils import make_positive_definite
@@ -170,6 +161,7 @@ class EnsembleMLP(Ensemble):
         **mlp_kwargs: dict
             Additional keyword arguments for the MLP constructor.
         """
+        self.mlp_kwargs = mlp_kwargs
         emulators = [
             MLP(
                 x,
@@ -327,6 +319,7 @@ class EnsembleMLPDropout(DropoutEnsemble):
         **mlp_kwargs: dict
             Additional keyword arguments for the MLP constructor.
         """
+        self.mlp_kwargs = mlp_kwargs
         super().__init__(
             MLP(
                 x,

--- a/autoemulate/emulators/random_forest.py
+++ b/autoemulate/emulators/random_forest.py
@@ -35,7 +35,6 @@ class RandomForest(SklearnBackend):
         max_samples: int | None = None,
         random_seed: int | None = None,
         device: DeviceLike = "cpu",
-        **kwargs,
     ):
         """Initialize a RandomForest emulator.
 


### PR DESCRIPTION
Closes #748 
Closes #757 

Overview:
- make sure all emulator models save all input args so that all input values can be retrieved
- update HMW so that user can pass emulator instead of result
- re-initialize emulators when refitting in AL