### PR TITLE
Fix ensemble tuning params bug

### DIFF
--- a/autoemulate/emulators/ensemble.py
+++ b/autoemulate/emulators/ensemble.py
@@ -139,7 +139,7 @@ class EnsembleMLP(Ensemble):
         standardize_y: bool = True,
         n_emulators: int = 4,
         device: DeviceLike | None = None,
-        mlp_kwargs: dict | None = None,
+        **mlp_kwargs,
     ):
         """
         Initialize an ensemble of MLPs.


### PR DESCRIPTION
The [quickstart tutorial](https://alan-turing-institute.github.io/autoemulate/tutorials/emulation/01_quickstart.html) failed to fit an `EnsembleMLP`, this PR fixes the issue.