### PR TITLE
Support for UQ with conformal prediction

### DIFF
--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -76,6 +76,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         log_level: str = "progress_bar",
         tuning_metric: str | Metric = "r2",
         evaluation_metrics: list[str | Metric] | None = None,
+        n_samples: int = 1000,
     ):
         """
         Initialize the AutoEmulate class.
@@ -135,6 +136,9 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
             Each entry can be a string shortcut or a MetricConfig object.
             IMPORTANT: The first metric in the list is used to
             determine the best model.
+        n_samples: int
+            Number of samples to generate to predict mean when emulator does not have a
+            mean directly available. Defaults to 1000.
         """
         Results.__init__(self)
         self.random_seed = random_seed
@@ -192,6 +196,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
         # Set up logger and ModelSerialiser for saving models
         self.logger, self.progress_bar = get_configured_logger(log_level)
         self.model_serialiser = ModelSerialiser(self.logger)
+        self.n_samples = n_samples
 
         # Run compare
         self.compare()
@@ -489,6 +494,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 n_bootstraps=self.n_bootstraps,
                                 device=self.device,
                                 metrics=self.evaluation_metrics,
+                                n_samples=self.n_samples,
                             )
                             test_metrics = bootstrap(
                                 transformed_emulator,
@@ -497,6 +503,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                 n_bootstraps=self.n_bootstraps,
                                 device=self.device,
                                 metrics=self.evaluation_metrics,
+                                n_samples=self.n_samples,
                             )
 
                             # Log all test metrics from test_metrics dictionary

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -422,6 +422,9 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                     n_splits=self.n_splits,
                                     shuffle=self.shuffle,
                                     transformed_emulator_params=self.transformed_emulator_params,
+                                    metric_params=MetricParams(
+                                        n_samples=self.n_samples
+                                    ),
                                 )
                                 mean_scores = [
                                     np.mean(score).item() for score in scores

--- a/autoemulate/core/model_selection.py
+++ b/autoemulate/core/model_selection.py
@@ -64,6 +64,7 @@ def cross_validate(
     device: DeviceLike = "cpu",
     random_seed: int | None = None,
     metrics: list[Metric] | None = None,
+    n_samples: int = 1000,
 ):
     """
     Cross validate model performance using the given `cv` strategy.
@@ -88,6 +89,9 @@ def cross_validate(
         Optional random seed for reproducibility.
     metrics: list[TorchMetrics] | None
         List of metrics to compute. If None, uses r2 and rmse.
+    n_samples: int
+        Number of samples to generate to predict mean when emulator does not have a
+        mean directly available. Defaults to 1000.
 
     Returns
     -------
@@ -146,7 +150,7 @@ def cross_validate(
         # compute and save results
         y_pred = transformed_emulator.predict(x_val)
         for metric in metrics:
-            score = evaluate(y_pred, y_val, metric)
+            score = evaluate(y_pred, y_val, metric, n_samples=n_samples)
             cv_results[metric.name].append(score)
     return cv_results
 

--- a/autoemulate/core/model_selection.py
+++ b/autoemulate/core/model_selection.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from dataclasses import replace
 
 import torch
 from sklearn.model_selection import BaseCrossValidator
@@ -147,7 +148,13 @@ def cross_validate(
         # compute and save results
         y_pred = transformed_emulator.predict(x_val)
         for metric in metrics:
-            score = evaluate(y_pred, y_val, metric, metric_params=metric_params)
+            score = evaluate(
+                # Update metric_params with y_train in case required by metric
+                y_pred,
+                y_val,
+                metric,
+                metric_params=replace(metric_params, y_train=y),
+            )
             cv_results[metric.name].append(score)
     return cv_results
 

--- a/autoemulate/core/tuner.py
+++ b/autoemulate/core/tuner.py
@@ -6,7 +6,7 @@ from sklearn.model_selection import KFold
 from torch.distributions import Transform
 
 from autoemulate.core.device import TorchDeviceMixin
-from autoemulate.core.metrics import Metric, get_metric
+from autoemulate.core.metrics import Metric, MetricParams, get_metric
 from autoemulate.core.model_selection import cross_validate
 from autoemulate.core.types import (
     DeviceLike,
@@ -74,6 +74,7 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
         n_splits: int = 5,
         seed: int | None = None,
         shuffle: bool = True,
+        metric_params: MetricParams | None = None,
     ) -> tuple[list[list[float]], list[ModelParams]]:
         """
         Run randomised hyperparameter search for a given model.
@@ -97,6 +98,8 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
         shuffle: bool
             Whether to shuffle data before splitting into cross validation folds.
             Defaults to True.
+        metric_params: MetricParams | None
+            Additional parameters to pass to the metrics. Defaults to None.
 
         Returns
         -------
@@ -130,6 +133,7 @@ class Tuner(ConversionMixin, TorchDeviceMixin):
                     device=self.device,
                     random_seed=None,
                     metrics=[self.tuning_metric],
+                    metric_params=metric_params,
                 )
 
                 # Reset retries following a successful cross_validation call

--- a/autoemulate/data/utils.py
+++ b/autoemulate/data/utils.py
@@ -206,6 +206,8 @@ class ConversionMixin:
             The output to convert to a tensor.
         n_samples: int
             Number of samples to draw from the distribution. Defaults to 1000.
+        with_grad: bool
+            Whether to enable gradient calculation. Defaults to False.
 
         Returns
         -------

--- a/autoemulate/data/utils.py
+++ b/autoemulate/data/utils.py
@@ -212,7 +212,8 @@ class ConversionMixin:
         Returns
         -------
         TensorLike
-            Tensor of shape (n_samples, output_dim) containing samples from the output.
+            Tensor of shape `(n_batch, n_targets)` as input or the mean of the output if
+            output is a distribution.
         """
         if isinstance(output, TensorLike):
             return output

--- a/autoemulate/data/utils.py
+++ b/autoemulate/data/utils.py
@@ -192,6 +192,39 @@ class ConversionMixin:
     ) -> TensorLike:
         return (x * x_std) + x_mean
 
+    def output_to_tensor(
+        self,
+        output: OutputLike,
+        n_samples: int = 1000,
+        with_grad: bool = False,
+    ) -> torch.Tensor:
+        """Convert an output to a tensor.
+
+        Parameters
+        ----------
+        output: OutputLike
+            The output to convert to a tensor.
+        n_samples: int
+            Number of samples to draw from the distribution. Defaults to 1000.
+
+        Returns
+        -------
+        TensorLike
+            Tensor of shape (n_samples, output_dim) containing samples from the output.
+        """
+        if isinstance(output, TensorLike):
+            return output
+        try:
+            return output.mean
+        except Exception:
+            # Use sampling to get a mean if mean property not available
+            samples = (
+                output.rsample(torch.Size([n_samples]))
+                if with_grad
+                else output.sample(torch.Size([n_samples]))
+            )
+            return samples.mean(dim=0)
+
 
 def set_random_seed(seed: int = 42, deterministic: bool = True):
     """

--- a/autoemulate/data/utils.py
+++ b/autoemulate/data/utils.py
@@ -198,7 +198,7 @@ class ConversionMixin:
         n_samples: int = 1000,
         with_grad: bool = False,
     ) -> torch.Tensor:
-        """Convert an output to a tensor.
+        """Convert an output to a tensor (returns the mean if output is a distribution).
 
         Parameters
         ----------

--- a/autoemulate/emulators/__init__.py
+++ b/autoemulate/emulators/__init__.py
@@ -1,4 +1,5 @@
 from .base import Emulator
+from .conformal import ConformalMLP
 from .ensemble import EnsembleMLP, EnsembleMLPDropout
 from .gaussian_process.exact import (
     GaussianProcessCorrelatedMatern32,
@@ -26,6 +27,7 @@ EMULATOR_REGISTRY_SHORT_NAME = _default_registry._emulator_registry_short_name
 
 __all__ = [
     "MLP",
+    "ConformalMLP",
     "Emulator",
     "EnsembleMLP",
     "EnsembleMLPDropout",

--- a/autoemulate/emulators/base.py
+++ b/autoemulate/emulators/base.py
@@ -162,18 +162,7 @@ class Emulator(ABC, ValidationMixin, ConversionMixin, TorchDeviceMixin):
         """
         x = self._ensure_with_grad(x, with_grad)
         y_pred = self._predict(x, with_grad)
-        if isinstance(y_pred, TensorLike):
-            return y_pred
-        try:
-            return y_pred.mean
-        except Exception:
-            # Use sampling to get a mean if mean property not available
-            samples = (
-                y_pred.rsample(torch.Size([n_samples]))
-                if with_grad
-                else y_pred.sample(torch.Size([n_samples]))
-            )
-            return samples.mean(dim=0)
+        return self.output_to_tensor(y_pred, n_samples)
 
     def predict_mean_and_variance(
         self, x: TensorLike, with_grad: bool = False, n_samples: int = 100

--- a/autoemulate/emulators/base.py
+++ b/autoemulate/emulators/base.py
@@ -39,9 +39,19 @@ class Emulator(ABC, ValidationMixin, ConversionMixin, TorchDeviceMixin):
     supports_uq: bool = False
 
     @abstractmethod
-    def _fit(self, x: TensorLike, y: TensorLike): ...
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ): ...
 
-    def fit(self, x: TensorLike, y: TensorLike):
+    def fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ):
         """Fit the emulator to the provided data."""
         # Ensure x and y are tensors and 2D
         x, y = self._convert_to_tensors(x, y)
@@ -58,7 +68,7 @@ class Emulator(ABC, ValidationMixin, ConversionMixin, TorchDeviceMixin):
         y = self.y_transform(y) if self.y_transform is not None else y
 
         # Fit emulator
-        self._fit(x, y)
+        self._fit(x, y, validation_data)
         self.is_fitted_ = True
 
     @abstractmethod
@@ -559,7 +569,12 @@ class PyTorchBackend(nn.Module, Emulator):
         """Loss function to be used for training the model."""
         return nn.MSELoss()(y_pred, y_true)
 
-    def _fit(self, x: TensorLike, y: TensorLike):
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         """
         Train a PyTorchBackend model.
 
@@ -683,7 +698,12 @@ class SklearnBackend(DeterministicEmulator):
     def _model_specific_check(self, x: NumpyLike, y: NumpyLike):
         _, _ = x, y
 
-    def _fit(self, x: TensorLike, y: TensorLike):
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         if self.normalize_y:
             y, y_mean, y_std = self._normalize(y)
             self.y_mean = y_mean

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -223,22 +223,22 @@ class Conformal(Emulator):
         lower_q = (1 - self.alpha) / 2
         upper_q = 1 - lower_q
 
-        # Create quantile regression emulators
-        mlp_kwargs = {
-            "epochs": 100,
-            "batch_size": 16,
-            "lr": 1e-2,
-            **self.quantile_emulator_kwargs,
-        }
-
         # Lower quantile emulator
         self.lower_quantile_emulator = QuantileMLP(
-            lower_q, x=x_train, y=y_train, device=self.device, **mlp_kwargs
+            lower_q,
+            x=x_train,
+            y=y_train,
+            device=self.device,
+            **self.quantile_emulator_kwargs,
         )
 
         # Upper quantile emulator
         self.upper_quantile_emulator = QuantileMLP(
-            upper_q, x=x_train, y=y_train, device=self.device, **mlp_kwargs
+            upper_q,
+            x=x_train,
+            y=y_train,
+            device=self.device,
+            **self.quantile_emulator_kwargs,
         )
 
         # Fit the quantile emulators

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -8,7 +8,7 @@ from torch.optim.lr_scheduler import LRScheduler
 from autoemulate.core.device import TorchDeviceMixin
 from autoemulate.core.types import DeviceLike, DistributionLike, TensorLike, TuneParams
 from autoemulate.emulators.base import Emulator, PyTorchBackend
-from autoemulate.emulators.nn.mlp import MLP
+from autoemulate.emulators.nn.mlp import MLP, _generate_mlp_docstring
 
 
 class QuantileLoss(nn.Module):
@@ -316,10 +316,6 @@ class ConformalMLP(Conformal, PyTorchBackend):
         y: TensorLike,
         standardize_x: bool = True,
         standardize_y: bool = True,
-        device: DeviceLike | None = None,
-        alpha: float = 0.95,
-        calibration_ratio: float = 0.2,
-        method: Literal["split", "quantile"] = "split",
         activation_cls: type[nn.Module] = nn.ReLU,
         loss_fn_cls: type[nn.Module] = nn.MSELoss,
         epochs: int = 100,
@@ -332,25 +328,18 @@ class ConformalMLP(Conformal, PyTorchBackend):
         lr: float = 1e-2,
         params_size: int = 1,
         random_seed: int | None = None,
+        device: DeviceLike | None = None,
         scheduler_cls: type[LRScheduler] | None = None,
         scheduler_params: dict | None = None,
+        alpha: float = 0.95,
+        calibration_ratio: float = 0.2,
+        method: Literal["split", "quantile"] = "split",
         quantile_emulator_kwargs: dict | None = None,
     ):
-        """
-        Initialize an ensemble of MLPs.
+        nn.Module.__init__(self)
 
-        Parameters
-        ----------
-        x: TensorLike
-            Input data tensor of shape (batch_size, n_features).
-        y: TensorLike
-            Target values tensor of shape (batch_size, n_outputs).
-        standardize_x: bool
-            Whether to standardize the input data. Defaults to True.
-        standardize_y: bool
-            Whether to standardize the output data. Defaults to True.
-        device: DeviceLike | None
-            Device to run the model on (e.g., "cpu", "cuda"). Defaults to None.
+        # Construct docstring
+        conformal_kwargs = """
         alpha: float
             Desired predictive coverage level forwarded to the conformal wrapper.
         calibration_ratio: float
@@ -361,48 +350,17 @@ class ConformalMLP(Conformal, PyTorchBackend):
             - "split": Standard split conformal (constant-width intervals)
             - "quantile": Conformalized Quantile Regression (input-dependent intervals)
             Defaults to "split".
-        activation_cls: type[nn.Module]
-            Activation function to use in the hidden layers. Defaults to `nn.ReLU`.
-        loss_fn_cls: type[nn.Module]
-            Loss function class used to construct the loss function for training.
-            Defaults to `nn.MSELoss`.
-        layer_dims: list[int] | None
-            Dimensions of the hidden layers. If None, defaults to [32, 16].
-            Defaults to None.
-        weight_init: str
-            Weight initialization method. Options are "default", "normal", "uniform",
-            "zeros", "ones", "xavier_uniform", "xavier_normal", "kaiming_uniform",
-            "kaiming_normal". Defaults to "default".
-        scale: float
-            Scale parameter for weight initialization methods. Used as:
-            - gain for Xavier methods
-            - std for normal distribution
-            - bound for uniform distribution (range: [-scale, scale])
-            - ignored for Kaiming methods (uses optimal scaling)
-            Defaults to 1.0.
-        bias_init: str
-            Bias initialization method. Options: "zeros", "default":
-                - "zeros" initializes biases to zero
-                - "default" uses PyTorch's default uniform initialization
-        dropout_prob: float | None
-            Dropout probability for regularization. If None, no dropout is applied.
-            Defaults to None.
-        lr: float
-            Learning rate for the optimizer. Defaults to 1e-2.
-        params_size: int
-            Number of parameters to predict per output dimension. Defaults to 1.
-        random_seed: int | None
-            Random seed for reproducibility. If None, no seed is set. Defaults to None.
-        scheduler_cls: type[LRScheduler] | None
-            Learning rate scheduler class. If None, no scheduler is used. Defaults to
-            None.
-        scheduler_params: dict | None
-            Additional keyword arguments related to the scheduler.
         quantile_emulator_kwargs: dict | None
             Additional keyword arguments for the quantile emulators when
             method="quantile". Defaults to None.
         """
-        nn.Module.__init__(self)
+        conformal_mlp_params = _generate_mlp_docstring(
+            additional_parameters_docstring=conformal_kwargs,
+            default_dropout_prob=None,
+        )
+        self.__doc__ = (
+            """    Initialize a conformal MLP emulator.\n\n""" + conformal_mlp_params
+        )
 
         emulator = MLP(
             x,

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -308,8 +308,11 @@ class Conformal(Emulator):
 class ConformalMLP(Conformal, PyTorchBackend):
     """Conformal UQ with an MLP.
 
-    This class is to provide ensemble of MLP emulators, each initialized with the same
-    input and output data.
+    This class is to provides UQ via conformal prediction intervals wrapped around a
+    Multi-Layer Perceptron (MLP) emulator.
+
+    Both standard split conformal and Conformalized Quantile Regression (CQR) methods
+    are supported.
 
     """
 

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -41,6 +41,9 @@ class Conformal(Emulator):
         calibration_ratio: float
             Fraction of the training data to reserve for calibration if explicit
             validation data is not provided. Must lie in (0, 1). Defaults to 0.2.
+        n_samples: int
+            Number of samples used for sampling-based predictions or
+            internal procedures. Defaults to 1000.
         """
         self.emulator = emulator
         self.supports_grad = emulator.supports_grad
@@ -178,8 +181,43 @@ class ConformalMLP(Conformal, PyTorchBackend):
         calibration_ratio: float
             Fraction of training samples to hold out for calibration when an explicit
             validation set is not provided.
-        mlp_kwargs: dict | None
-            Additional keyword arguments for the MLP constructor.
+        activation_cls: type[nn.Module]
+            Activation function to use in the hidden layers. Defaults to `nn.ReLU`.
+        loss_fn_cls: type[nn.Module]
+            Loss function class used to construct the loss function for training.
+            Defaults to `nn.MSELoss`.
+        layer_dims: list[int] | None
+            Dimensions of the hidden layers. If None, defaults to [32, 16].
+            Defaults to None.
+        weight_init: str
+            Weight initialization method. Options are "default", "normal", "uniform",
+            "zeros", "ones", "xavier_uniform", "xavier_normal", "kaiming_uniform",
+            "kaiming_normal". Defaults to "default".
+        scale: float
+            Scale parameter for weight initialization methods. Used as:
+            - gain for Xavier methods
+            - std for normal distribution
+            - bound for uniform distribution (range: [-scale, scale])
+            - ignored for Kaiming methods (uses optimal scaling)
+            Defaults to 1.0.
+        bias_init: str
+            Bias initialization method. Options: "zeros", "default":
+                - "zeros" initializes biases to zero
+                - "default" uses PyTorch's default uniform initialization
+        dropout_prob: float | None
+            Dropout probability for regularization. If None, no dropout is applied.
+            Defaults to None.
+        lr: float
+            Learning rate for the optimizer. Defaults to 1e-2.
+        params_size: int
+            Number of parameters to predict per output dimension. Defaults to 1.
+        random_seed: int | None
+            Random seed for reproducibility. If None, no seed is set. Defaults to None.
+        scheduler_cls: type[LRScheduler] | None
+            Learning rate scheduler class. If None, no scheduler is used. Defaults to
+            None.
+        scheduler_params: dict | None
+            Additional keyword arguments related to the scheduler.
         """
         nn.Module.__init__(self)
 

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -541,9 +541,6 @@ def create_conformal_subclass(
     alpha: float = fixed_kwargs.get("alpha", 0.95)
     calibration_ratio: float = fixed_kwargs.get("calibration_ratio", 0.2)
     quantile_emulator_kwargs: dict | None = fixed_kwargs.get("quantile_emulator_kwargs")
-    epochs = fixed_kwargs.get("epochs", 50)
-    lr = fixed_kwargs.get("lr", 2e-1)
-    device = fixed_kwargs.get("device")
 
     class ConformalMLPSubclass(conformal_mlp_base_class):
         def __init__(
@@ -603,19 +600,18 @@ def create_conformal_subclass(
             """Get tunable parameters, excluding those that are fixed."""
             tune_params = conformal_mlp_base_class.get_tune_params()
             # Remove fixed parameters from tuning
-            tune_params.pop("mean_module_fn", None)
-            tune_params.pop("covar_module_fn", None)
+            tune_params.pop("method", None)
             for key in fixed_kwargs:
                 tune_params.pop(key, None)
             return tune_params
 
     # Create a more descriptive docstring that includes fixed parameters
-    mean_covar_and_fixed_kwargs = {
+    method_and_fixed_kwargs = {
         **fixed_kwargs,
     }
     fixed_params_str = "\n    ".join(
         f"- {k} = {v.__name__ if callable(v) else v}"
-        for k, v in mean_covar_and_fixed_kwargs.items()
+        for k, v in method_and_fixed_kwargs.items()
     )
 
     ConformalMLPSubclass.__doc__ = f"""

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -1,7 +1,8 @@
 import math
 
 import torch
-from torch import Tensor
+from torch import Tensor, nn
+from torch.optim.lr_scheduler import LRScheduler
 
 from autoemulate.core.device import TorchDeviceMixin
 from autoemulate.core.types import DeviceLike, DistributionLike, TensorLike, TuneParams
@@ -142,7 +143,20 @@ class ConformalMLP(Conformal, PyTorchBackend):
         device: DeviceLike | None = None,
         alpha: float = 0.95,
         calibration_ratio: float = 0.2,
-        **mlp_kwargs,
+        activation_cls: type[nn.Module] = nn.ReLU,
+        loss_fn_cls: type[nn.Module] = nn.MSELoss,
+        epochs: int = 100,
+        batch_size: int = 16,
+        layer_dims: list[int] | None = None,
+        weight_init: str = "default",
+        scale: float = 1.0,
+        bias_init: str = "default",
+        dropout_prob: float | None = None,
+        lr: float = 1e-2,
+        params_size: int = 1,
+        random_seed: int | None = None,
+        scheduler_cls: type[LRScheduler] | None = None,
+        scheduler_params: dict | None = None,
     ):
         """
         Initialize an ensemble of MLPs.
@@ -167,15 +181,28 @@ class ConformalMLP(Conformal, PyTorchBackend):
         mlp_kwargs: dict | None
             Additional keyword arguments for the MLP constructor.
         """
-        PyTorchBackend.__init__(self)
-        self.mlp_kwargs = mlp_kwargs or {}
+        nn.Module.__init__(self)
+
         emulator = MLP(
             x,
             y,
             standardize_x=standardize_x,
             standardize_y=standardize_y,
             device=device,
-            **self.mlp_kwargs,
+            activation_cls=activation_cls,
+            loss_fn_cls=loss_fn_cls,
+            epochs=epochs,
+            batch_size=batch_size,
+            layer_dims=layer_dims,
+            weight_init=weight_init,
+            scale=scale,
+            bias_init=bias_init,
+            dropout_prob=dropout_prob,
+            lr=lr,
+            params_size=params_size,
+            random_seed=random_seed,
+            scheduler_cls=scheduler_cls,
+            scheduler_params=scheduler_params,
         )
         Conformal.__init__(
             self,

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -115,7 +115,9 @@ class Conformal(Emulator):
         method: Literal["constant", "quantile"] = "constant",
         to_distribution: Callable[
             [TensorLike | None, tuple[TensorLike, TensorLike]], DistributionLike
-        ] = lambda _mean, bounds: torch.distributions.Uniform(bounds[0], bounds[1]),
+        ] = lambda _mean, bounds: torch.distributions.Uniform(
+            torch.min(bounds[0], bounds[1]), torch.max(bounds[0], bounds[1])
+        ),
         quantile_emulator_kwargs: dict | None = None,
     ):
         """Initialize a conformal emulator.

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -81,6 +81,21 @@ class Conformal(Emulator):
 
     This class wraps a base emulator to provide conformal prediction intervals with
     guaranteed frequentist coverage.
+
+    Both standard split conformal and Conformalized Quantile Regression (CQR) methods
+    are supported.
+
+    Conformalized Quantile Regression (CQR) is defaultly implemented with two neural net
+    quantile regressors predicting lower and upper quantiles, followed by a calibration
+    step to ensure valid coverage. Note the _fit_quantile_regressors method can be
+    overridden to implement custom quantile regressors.
+
+    References
+    ----------
+    - Romano, Y., Patterson, E., & Candes, E. (2019). Conformalized Quantile Regression.
+      In Advances in Neural Information Processing Systems (Vol. 32).
+      https://papers.nips.cc/paper/8613-conformalized-quantile-regression.pdf
+
     """
 
     supports_uq = True

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -90,6 +90,10 @@ class Conformal(Emulator):
     step to ensure valid coverage. Note the _fit_quantile_regressors method can be
     overridden to implement custom quantile regressors.
 
+    Additional methods for input-dependent intervals (such as scaling) can be
+    implemented by adding further supported "method" strings and providing corresponding
+    logic in the _fit and _predict methods.
+
     References
     ----------
     - Romano, Y., Patterson, E., & Candes, E. (2019). Conformalized Quantile Regression.

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -154,7 +154,7 @@ class Conformal(Emulator):
         x: TensorLike,
         y: TensorLike,
         validation_data: tuple[TensorLike, TensorLike] | None = None,
-    ) -> None:
+    ):
         x_train, y_train = x, y
         if validation_data is None:
             n_samples = x.shape[0]
@@ -213,7 +213,7 @@ class Conformal(Emulator):
         y_train: TensorLike,
         x_cal: TensorLike,
         y_true_cal: TensorLike,
-    ) -> None:
+    ):
         """Fit quantile regressors for CQR method.
 
         Trains two quantile regressors to predict lower and upper quantiles,

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -137,7 +137,7 @@ class Conformal(Emulator):
             msg = "Calibration ratio must lie strictly between 0 and 1."
             raise ValueError(msg)
         if method not in {"constant", "quantile"}:
-            msg = f"Method must be 'split' or 'quantile', got '{method}'."
+            msg = f"Method must be 'constant' or 'quantile', got '{method}'."
             raise ValueError(msg)
         self.alpha = alpha  # desired predictive coverage (e.g., 0.95)
         self.calibration_ratio = calibration_ratio

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -156,6 +156,9 @@ class Conformal(Emulator):
         validation_data: tuple[TensorLike, TensorLike] | None = None,
     ):
         x_train, y_train = x, y
+
+        # If not validation data passed, take random permutation of training data and
+        # hold out a calibration set according to calibration_ratio
         if validation_data is None:
             n_samples = x.shape[0]
             if n_samples < 2:

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -1,0 +1,145 @@
+import math
+
+import torch
+from torch import Tensor
+
+from autoemulate.core.device import TorchDeviceMixin
+from autoemulate.core.types import DeviceLike, DistributionLike, TensorLike, TuneParams
+from autoemulate.emulators.base import Emulator, PyTorchBackend
+from autoemulate.emulators.nn.mlp import MLP
+
+
+class Conformal(Emulator):
+    """
+    Ensemble emulator that aggregates multiple Emulator instances to provide UQ.
+
+    Ensemble emulator that aggregates multiple Emulator instances and returns
+    a GaussianLike representing the ensemble posterior.
+    Note that an Emulator instance may also be an Ensemble itself.
+    """
+
+    def __init__(
+        self,
+        emulator: Emulator,
+        alpha: float = 0.95,
+        device: DeviceLike | None = None,
+    ):
+        self.emulator = emulator
+        self.supports_grad = emulator.supports_grad
+        if not 0 < alpha < 1:
+            msg = "Conformal coverage level alpha must be in (0, 1)."
+            raise ValueError(msg)
+        self.alpha = alpha  # desired predictive coverage (e.g., 0.95)
+        self.n_samples = 1000  # number of samples to draw from base emulator if needed
+        TorchDeviceMixin.__init__(self, device=device)
+
+    @staticmethod
+    def is_multioutput() -> bool:
+        """Ensemble supports multi-output."""
+        return True
+
+    @staticmethod
+    def get_tune_params() -> TuneParams:
+        """Return a dictionary of hyperparameters to tune."""
+        return {}
+
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ) -> None:
+        self.emulator.fit(x, y, validation_data=None)
+
+        with torch.no_grad():
+            if validation_data is None:
+                msg = "Conformal emulator requires calibration data for quantiles."
+                raise ValueError(msg)
+
+            # Destructure calibration data
+            x_cal, y_true_cal = validation_data
+
+            n_cal = x_cal.shape[0]
+            # Check calibration data is non-empty
+            if n_cal == 0:
+                msg = "Calibration set must contain at least one sample."
+                raise ValueError(msg)
+
+            # Predict and calculate residuals
+            y_pred_cal = self.output_to_tensor(self.emulator.predict(x_cal))
+            residuals = torch.abs(y_true_cal - y_pred_cal)
+
+            # Apply finite-sample correction to quantile level to ensure valid coverage
+            quantile_level = min(1.0, math.ceil((n_cal + 1) * self.alpha) / n_cal)
+
+            # Calibrate over the batch dim with a separate quantile for each output
+            self.q = torch.quantile(residuals, quantile_level, dim=0)
+
+        self.is_fitted_ = True
+
+    def _predict(self, x: Tensor, with_grad: bool) -> DistributionLike:
+        pred = self.emulator.predict(x, with_grad)
+        mean = self.output_to_tensor(pred)
+        q = self.q.to(mean.device)
+        return torch.distributions.Independent(
+            torch.distributions.Uniform(mean - q, mean + q),
+            reinterpreted_batch_ndims=mean.ndim - 1,
+        )
+
+
+class ConformalMLP(Conformal, PyTorchBackend):
+    """
+    Conformal UQ with an MLP.
+
+    This class is to provide ensemble of MLP emulators, each initialized with the same
+    input and output data.
+
+    """
+
+    def __init__(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        standardize_x: bool = True,
+        standardize_y: bool = True,
+        device: DeviceLike | None = None,
+        **mlp_kwargs,
+    ):
+        """
+        Initialize an ensemble of MLPs.
+
+        Parameters
+        ----------
+        x: TensorLike
+            Input data tensor of shape (batch_size, n_features).
+        y: TensorLike
+            Target values tensor of shape (batch_size, n_outputs).
+        standardize_x: bool
+            Whether to standardize the input data. Defaults to True.
+        standardize_y: bool
+            Whether to standardize the output data. Defaults to True.
+        device: DeviceLike | None
+            Device to run the model on (e.g., "cpu", "cuda"). Defaults to None.
+        mlp_kwargs: dict | None
+            Additional keyword arguments for the MLP constructor.
+        """
+        self.mlp_kwargs = mlp_kwargs or {}
+        emulator = MLP(
+            x,
+            y,
+            standardize_x=standardize_x,
+            standardize_y=standardize_y,
+            device=device,
+            **self.mlp_kwargs,
+        )
+        super().__init__(emulator, device=device)
+
+    @staticmethod
+    def is_multioutput() -> bool:
+        """Ensemble of MLPs supports multi-output."""
+        return True
+
+    @staticmethod
+    def get_tune_params() -> TuneParams:
+        """Return a dictionary of hyperparameters to tune."""
+        return MLP.get_tune_params()

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -1,13 +1,77 @@
 import math
+from typing import Literal
 
 import torch
-from torch import Tensor, nn
+from torch import nn
 from torch.optim.lr_scheduler import LRScheduler
 
 from autoemulate.core.device import TorchDeviceMixin
 from autoemulate.core.types import DeviceLike, DistributionLike, TensorLike, TuneParams
 from autoemulate.emulators.base import Emulator, PyTorchBackend
 from autoemulate.emulators.nn.mlp import MLP
+
+
+class QuantileLoss(nn.Module):
+    """Quantile loss for quantile regression.
+
+    This loss function asymmetrically penalizes over- and under-predictions, enabling
+    the model to learn specific quantiles of the conditional distribution.
+    """
+
+    def __init__(self, quantile: float):
+        """Initialize quantile loss.
+
+        Parameters
+        ----------
+        quantile: float
+            Target quantile level in (0, 1). For example, 0.1 for 10th percentile, 0.5
+            for median, 0.9 for 90th percentile.
+        """
+        super().__init__()
+        if not 0 < quantile < 1:
+            msg = f"Quantile must be in (0, 1), got {quantile}"
+            raise ValueError(msg)
+        self.quantile = quantile
+
+    def forward(self, y_pred: TensorLike, y_true: TensorLike) -> TensorLike:
+        """Compute quantile loss.
+
+        Parameters
+        ----------
+        y_pred: TensorLike
+            Predicted values.
+        y_true: TensorLike
+            True target values.
+
+        Returns
+        -------
+        TensorLike
+            Scalar loss value.
+        """
+        errors = y_true - y_pred
+        return torch.max(self.quantile * errors, (self.quantile - 1) * errors).mean()
+
+
+class QuantileMLP(MLP):
+    """MLP with quantile loss for quantile regression."""
+
+    def __init__(self, quantile: float, **kwargs):
+        """Initialize quantile MLP.
+
+        Parameters
+        ----------
+        quantile: float
+            Target quantile level in (0, 1).
+        **kwargs
+            Keyword arguments passed to MLP parent class.
+        """
+        super().__init__(**kwargs)
+        self.quantile = quantile
+        self.quantile_loss = QuantileLoss(quantile)
+
+    def loss_func(self, y_pred, y_true):
+        """Quantile loss function."""
+        return self.quantile_loss(y_pred, y_true)
 
 
 class Conformal(Emulator):
@@ -26,6 +90,8 @@ class Conformal(Emulator):
         device: DeviceLike | None = None,
         calibration_ratio: float = 0.2,
         n_samples: int = 1000,
+        method: Literal["split", "quantile"] = "split",
+        quantile_emulator_kwargs: dict | None = None,
     ):
         """Initialize a conformal emulator.
 
@@ -42,8 +108,16 @@ class Conformal(Emulator):
             Fraction of the training data to reserve for calibration if explicit
             validation data is not provided. Must lie in (0, 1). Defaults to 0.2.
         n_samples: int
-            Number of samples used for sampling-based predictions or
-            internal procedures. Defaults to 1000.
+            Number of samples used for sampling-based predictions or internal
+            procedures. Defaults to 1000.
+        method: Literal["split", "quantile"]
+            Conformalization method to use:
+            - "split": Standard split conformal with constant-width intervals
+            - "quantile": Conformalized Quantile Regression (CQR) with input-dependent
+              intervals. Defaults to "split".
+        quantile_emulator_kwargs: dict | None
+            Additional keyword arguments for the quantile emulators when
+            method="quantile". Defaults to None.
         """
         self.emulator = emulator
         self.supports_grad = emulator.supports_grad
@@ -53,9 +127,14 @@ class Conformal(Emulator):
         if not 0 < calibration_ratio < 1:
             msg = "Calibration ratio must lie strictly between 0 and 1."
             raise ValueError(msg)
+        if method not in {"split", "quantile"}:
+            msg = f"Method must be 'split' or 'quantile', got '{method}'."
+            raise ValueError(msg)
         self.alpha = alpha  # desired predictive coverage (e.g., 0.95)
         self.calibration_ratio = calibration_ratio
         self.n_samples = n_samples
+        self.method = method
+        self.quantile_emulator_kwargs = quantile_emulator_kwargs or {}
         TorchDeviceMixin.__init__(self, device=device)
         self.supports_grad = emulator.supports_grad
 
@@ -98,35 +177,128 @@ class Conformal(Emulator):
         else:
             x_cal, y_true_cal = validation_data
 
+        # Fit the base emulator
         self.emulator.fit(x_train, y_train, validation_data=None)
 
-        with torch.no_grad():
-            n_cal = x_cal.shape[0]
-            # Check calibration data is non-empty
-            if n_cal == 0:
-                msg = "Calibration set must contain at least one sample."
-                raise ValueError(msg)
+        n_cal = x_cal.shape[0]
+        # Check calibration data is non-empty
+        if n_cal == 0:
+            msg = "Calibration set must contain at least one sample."
+            raise ValueError(msg)
 
+        with torch.no_grad():
             # Predict and calculate residuals
             y_pred_cal = self.output_to_tensor(self.emulator.predict(x_cal))
+
+        if self.method == "split":
+            # Standard split conformal: compute global quantile of residuals
             residuals = torch.abs(y_true_cal - y_pred_cal)
 
-            # Apply finite-sample correction to quantile level to ensure valid coverage
+            # Apply finite-sample correction to quantile level
             quantile_level = min(1.0, math.ceil((n_cal + 1) * self.alpha) / n_cal)
 
-            # Calibrate over the batch dim with a separate quantile for each output
+            # Calibrate over the batch dim with a separate quantile per output
             self.q = torch.quantile(residuals, quantile_level, dim=0)
+
+        elif self.method == "quantile":
+            # Conformalized Quantile Regression: train quantile regressors
+            self._fit_quantile_regressors(x_train, y_train, x_cal, y_true_cal)
 
         self.is_fitted_ = True
 
-    def _predict(self, x: Tensor, with_grad: bool) -> DistributionLike:
-        pred = self.emulator.predict(x, with_grad)
-        mean = self.output_to_tensor(pred)
-        q = self.q.to(mean.device)
-        return torch.distributions.Independent(
-            torch.distributions.Uniform(mean - q, mean + q),
-            reinterpreted_batch_ndims=mean.ndim - 1,
+    def _fit_quantile_regressors(
+        self,
+        x_train: TensorLike,
+        y_train: TensorLike,
+        x_cal: TensorLike,
+        y_true_cal: TensorLike,
+    ) -> None:
+        """Fit quantile regressors for CQR method.
+
+        Trains two quantile regressors to predict lower and upper quantiles,
+        then calibrates the width using the calibration set.
+        """
+        # Calculate quantile levels
+        lower_q = (1 - self.alpha) / 2
+        upper_q = 1 - lower_q
+
+        # Create quantile regression emulators
+        mlp_kwargs = {
+            "epochs": 100,
+            "batch_size": 16,
+            "lr": 1e-2,
+            **self.quantile_emulator_kwargs,
+        }
+
+        # Lower quantile emulator
+        self.lower_quantile_emulator = QuantileMLP(
+            lower_q, x=x_train, y=y_train, device=self.device, **mlp_kwargs
         )
+
+        # Upper quantile emulator
+        self.upper_quantile_emulator = QuantileMLP(
+            upper_q, x=x_train, y=y_train, device=self.device, **mlp_kwargs
+        )
+
+        # Fit the quantile emulators
+        self.lower_quantile_emulator.fit(x_train, y_train, validation_data=None)
+        self.upper_quantile_emulator.fit(x_train, y_train, validation_data=None)
+
+        # Predict quantiles on calibration set
+        with torch.no_grad():
+            lower_pred_cal = self.output_to_tensor(
+                self.lower_quantile_emulator.predict(x_cal)
+            )
+            upper_pred_cal = self.output_to_tensor(
+                self.upper_quantile_emulator.predict(x_cal)
+            )
+
+            # Calculate conformalization scores (non-conformity scores)
+            # For CQR, the score is max(lower - y, y - upper)
+            scores = torch.maximum(
+                lower_pred_cal - y_true_cal, y_true_cal - upper_pred_cal
+            )
+
+            # Apply finite-sample correction
+            n_cal = x_cal.shape[0]
+            quantile_level = min(1.0, math.ceil((n_cal + 1) * self.alpha) / n_cal)
+
+            # Compute the correction term per output dimension
+            self.q_cqr = torch.quantile(scores, quantile_level, dim=0)
+
+    def _predict(self, x: TensorLike, with_grad: bool) -> DistributionLike:
+        if self.method == "split":
+            # Standard split conformal: constant-width intervals
+            pred = self.emulator.predict(x, with_grad)
+            mean = self.output_to_tensor(pred)
+            q = self.q.to(mean.device)
+            return torch.distributions.Independent(
+                torch.distributions.Uniform(mean - q, mean + q),
+                reinterpreted_batch_ndims=mean.ndim - 1,
+            )
+
+        if self.method == "quantile":
+            # CQR: input-dependent intervals
+            lower_pred = self.output_to_tensor(
+                self.lower_quantile_emulator.predict(x, with_grad)
+            )
+            upper_pred = self.output_to_tensor(
+                self.upper_quantile_emulator.predict(x, with_grad)
+            )
+            q_cqr = self.q_cqr.to(lower_pred.device)
+
+            # Apply calibration correction
+            lower_bound = lower_pred - q_cqr
+            upper_bound = upper_pred + q_cqr
+
+            # Return uniform distribution over the calibrated interval
+            return torch.distributions.Independent(
+                torch.distributions.Uniform(lower_bound, upper_bound),
+                reinterpreted_batch_ndims=lower_bound.ndim - 1,
+            )
+
+        msg = f"Unknown method: {self.method}"
+        raise ValueError(msg)
 
 
 class ConformalMLP(Conformal, PyTorchBackend):
@@ -146,6 +318,7 @@ class ConformalMLP(Conformal, PyTorchBackend):
         device: DeviceLike | None = None,
         alpha: float = 0.95,
         calibration_ratio: float = 0.2,
+        method: Literal["split", "quantile"] = "split",
         activation_cls: type[nn.Module] = nn.ReLU,
         loss_fn_cls: type[nn.Module] = nn.MSELoss,
         epochs: int = 100,
@@ -160,6 +333,7 @@ class ConformalMLP(Conformal, PyTorchBackend):
         random_seed: int | None = None,
         scheduler_cls: type[LRScheduler] | None = None,
         scheduler_params: dict | None = None,
+        quantile_emulator_kwargs: dict | None = None,
     ):
         """
         Initialize an ensemble of MLPs.
@@ -181,6 +355,11 @@ class ConformalMLP(Conformal, PyTorchBackend):
         calibration_ratio: float
             Fraction of training samples to hold out for calibration when an explicit
             validation set is not provided.
+        method: Literal["split", "quantile"]
+            Conformalization method:
+            - "split": Standard split conformal (constant-width intervals)
+            - "quantile": Conformalized Quantile Regression (input-dependent intervals)
+            Defaults to "split".
         activation_cls: type[nn.Module]
             Activation function to use in the hidden layers. Defaults to `nn.ReLU`.
         loss_fn_cls: type[nn.Module]
@@ -218,6 +397,9 @@ class ConformalMLP(Conformal, PyTorchBackend):
             None.
         scheduler_params: dict | None
             Additional keyword arguments related to the scheduler.
+        quantile_emulator_kwargs: dict | None
+            Additional keyword arguments for the quantile emulators when
+            method="quantile". Defaults to None.
         """
         nn.Module.__init__(self)
 
@@ -242,12 +424,37 @@ class ConformalMLP(Conformal, PyTorchBackend):
             scheduler_cls=scheduler_cls,
             scheduler_params=scheduler_params,
         )
+
+        quantile_defaults = {
+            "standardize_x": standardize_x,
+            "standardize_y": standardize_y,
+            "activation_cls": activation_cls,
+            "loss_fn_cls": loss_fn_cls,
+            "epochs": epochs,
+            "batch_size": batch_size,
+            "layer_dims": layer_dims,
+            "weight_init": weight_init,
+            "scale": scale,
+            "bias_init": bias_init,
+            "dropout_prob": dropout_prob,
+            "lr": lr,
+            "params_size": params_size,
+            "random_seed": random_seed,
+            "scheduler_cls": scheduler_cls,
+            "scheduler_params": scheduler_params,
+        }
+        merged_quantile_kwargs = {
+            **quantile_defaults,
+            **(quantile_emulator_kwargs or {}),
+        }
         Conformal.__init__(
             self,
             emulator=emulator,
             alpha=alpha,
             device=device,
             calibration_ratio=calibration_ratio,
+            method=method,
+            quantile_emulator_kwargs=merged_quantile_kwargs,
         )
 
     @staticmethod

--- a/autoemulate/emulators/conformal.py
+++ b/autoemulate/emulators/conformal.py
@@ -49,6 +49,7 @@ class QuantileLoss(nn.Module):
             Scalar loss value.
         """
         errors = y_true - y_pred
+        # Mean across batch and targets
         return torch.max(self.quantile * errors, (self.quantile - 1) * errors).mean()
 
 

--- a/autoemulate/emulators/ensemble.py
+++ b/autoemulate/emulators/ensemble.py
@@ -164,16 +164,13 @@ class EnsembleMLP(Ensemble):
         n_emulators: int
             Number of MLP emulators to create in the ensemble. Defaults to 4.
         """
-        self.__doc__ = f"""
-        Initialize an ensemble of MLPs.
-
-        {
-            _generate_mlp_docstring(
+        self.__doc__ = (
+            "    Initialize an ensemble of MLPs.\n"
+            + _generate_mlp_docstring(
                 additional_parameters_docstring=additional_parameters_docstring,
                 default_dropout_prob=None,
             )
-        }
-        """
+        )
 
         emulators = [
             MLP(
@@ -342,15 +339,12 @@ class EnsembleMLPDropout(DropoutEnsemble):
         scheduler_cls: type[LRScheduler] | None = None,
         scheduler_params: dict | None = None,
     ):
-        self.__doc__ = f"""
-        Initialize an ensemble of MLPs with dropout.
-
-        {
-            _generate_mlp_docstring(
+        self.__doc__ = (
+            "    Initialize an ensemble of MLPs with dropout.\n"
+            + _generate_mlp_docstring(
                 additional_parameters_docstring="", default_dropout_prob=0.2
             )
-        }
-        """
+        )
         DropoutEnsemble.__init__(
             self,
             MLP(

--- a/autoemulate/emulators/ensemble.py
+++ b/autoemulate/emulators/ensemble.py
@@ -58,9 +58,14 @@ class Ensemble(GaussianEmulator):
         """Return a dictionary of hyperparameters to tune."""
         return {}
 
-    def _fit(self, x: TensorLike, y: TensorLike) -> None:
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ) -> None:
         for e in self.emulators:
-            e.fit(x, y)
+            e.fit(x, y, validation_data=validation_data)
         self.is_fitted_ = True
 
     def _predict(self, x: Tensor, with_grad: bool) -> GaussianLike:
@@ -240,9 +245,14 @@ class DropoutEnsemble(GaussianEmulator, TorchDeviceMixin):
             "n_samples": [10, 20, 50, 100],
         }
 
-    def _fit(self, x: TensorLike, y: TensorLike) -> None:
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ) -> None:
         # Delegate training to the wrapped model
-        self.model.fit(x, y)
+        self.model.fit(x, y, validation_data=validation_data)
         self.is_fitted_ = True
 
     def _predict(self, x: Tensor, with_grad: bool) -> GaussianLike:

--- a/autoemulate/emulators/gaussian_process/exact.py
+++ b/autoemulate/emulators/gaussian_process/exact.py
@@ -190,7 +190,12 @@ class GaussianProcess(GaussianProcessEmulator, gpytorch.models.ExactGP):
             MultivariateNormal(mean, covar)
         )
 
-    def _fit(self, x: TensorLike, y: TensorLike):
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         self.train()
         self.likelihood.train()
 

--- a/autoemulate/emulators/lightgbm.py
+++ b/autoemulate/emulators/lightgbm.py
@@ -157,7 +157,12 @@ class LightGBM(DeterministicEmulator):
         """LightGBM does not support multi-output."""
         return False
 
-    def _fit(self, x: TensorLike, y: TensorLike):  # type: ignore since this is valid subclass of types
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ) -> None:
         x_np, y_np = self._convert_to_numpy(x, y)
         self.n_features_in_ = x_np.shape[1]
         self.model_.fit(x_np, y_np)

--- a/autoemulate/emulators/nn/mlp.py
+++ b/autoemulate/emulators/nn/mlp.py
@@ -125,17 +125,15 @@ class MLP(DropoutTorchBackend):
         scheduler_cls: type[LRScheduler] | None = None,
         scheduler_params: dict | None = None,
     ):
-        self.__doc__ = f"""
-        Multi-Layer Perceptron (MLP) emulator.
-
-        MLP provides a simple deterministic emulator with optional model stochasticity
-        provided by different weight initialization and dropout.
-        {
-            _generate_mlp_docstring(
+        self.__doc__ = (
+            "    Multi-Layer Perceptron (MLP) emulator.\n\n"
+            "    MLP provides a simple deterministic emulator with optional model\n"
+            "    stochasticity provided by different weight initialization and "
+            "    dropout.\n"
+            + _generate_mlp_docstring(
                 additional_parameters_docstring="", default_dropout_prob=None
             )
-        }
-        """
+        )
         TorchDeviceMixin.__init__(self, device=device)
         nn.Module.__init__(self)
 

--- a/autoemulate/emulators/radial_basis_functions.py
+++ b/autoemulate/emulators/radial_basis_functions.py
@@ -69,7 +69,12 @@ class RadialBasisFunctions(PyTorchBackend):
         self.degree = degree
         self.device = device
 
-    def _fit(self, x: TensorLike, y: TensorLike):
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         self.model = RBFInterpolator(
             x,
             y,

--- a/autoemulate/emulators/registry.py
+++ b/autoemulate/emulators/registry.py
@@ -3,7 +3,7 @@ from typing import overload
 
 import torch
 
-from autoemulate.emulators.conformal import ConformalMLP
+from autoemulate.emulators.conformal import ConformalMLPConstant, ConformalMLPQuantile
 
 from .base import Emulator, GaussianProcessEmulator
 from .ensemble import EnsembleMLP, EnsembleMLPDropout
@@ -52,7 +52,8 @@ class Registry:
             GaussianProcessCorrelatedMatern32,
             GaussianProcessCorrelatedRBF,
             EnsembleMLPDropout,
-            ConformalMLP,
+            ConformalMLPConstant,
+            ConformalMLPQuantile,
         ]
 
         self._pytorch_emulators: list[type[Emulator]] = [

--- a/autoemulate/emulators/registry.py
+++ b/autoemulate/emulators/registry.py
@@ -3,6 +3,8 @@ from typing import overload
 
 import torch
 
+from autoemulate.emulators.conformal import ConformalMLP
+
 from .base import Emulator, GaussianProcessEmulator
 from .ensemble import EnsembleMLP, EnsembleMLPDropout
 from .gaussian_process.exact import (
@@ -50,6 +52,7 @@ class Registry:
             GaussianProcessCorrelatedMatern32,
             GaussianProcessCorrelatedRBF,
             EnsembleMLPDropout,
+            ConformalMLP,
         ]
 
         self._pytorch_emulators: list[type[Emulator]] = [

--- a/autoemulate/emulators/transformed/base.py
+++ b/autoemulate/emulators/transformed/base.py
@@ -356,7 +356,12 @@ class TransformedEmulator(Emulator, ValidationMixin, ConversionMixin):
         """
         return TransformedDistribution(y_t, [ComposeTransform(self.y_transforms).inv])
 
-    def _fit(self, x: TensorLike, y: TensorLike):
+    def _fit(
+        self,
+        x: TensorLike,
+        y: TensorLike,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         # Transform x and y
         x_t = self._transform_x(x)
         y_t = self._transform_y_tensor(y)

--- a/autoemulate/experimental/emulators/fno.py
+++ b/autoemulate/experimental/emulators/fno.py
@@ -58,7 +58,12 @@ class FNOEmulator(SpatioTemporalEmulator):
     def is_multioutput() -> bool:  # noqa: D102
         return True
 
-    def _fit(self, x: TensorLike | DataLoader, y: TensorLike | None = None):
+    def _fit(
+        self,
+        x: TensorLike | DataLoader,
+        y: TensorLike | None = None,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         assert isinstance(x, DataLoader), "x currently must be a DataLoader"
         assert y is None, "y currently must be None"
 

--- a/autoemulate/experimental/emulators/spatiotemporal.py
+++ b/autoemulate/experimental/emulators/spatiotemporal.py
@@ -11,7 +11,12 @@ class SpatioTemporalEmulator(PyTorchBackend):
 
     channels: tuple[int, ...]
 
-    def fit(self, x: TensorLike | DataLoader, y: TensorLike | None = None):
+    def fit(
+        self,
+        x: TensorLike | DataLoader,
+        y: TensorLike | None = None,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,  # noqa: ARG002
+    ):
         """Train a spatio-temporal emulator.
 
         Parameters
@@ -30,7 +35,12 @@ class SpatioTemporalEmulator(PyTorchBackend):
         raise RuntimeError(msg)
 
     @abstractmethod
-    def _fit(self, x: TensorLike | DataLoader, y: TensorLike | None = None): ...
+    def _fit(
+        self,
+        x: TensorLike | DataLoader,
+        y: TensorLike | None = None,
+        validation_data: tuple[TensorLike, TensorLike] | None = None,
+    ): ...
 
     def predict(
         self,

--- a/tests/core/test_model_selection.py
+++ b/tests/core/test_model_selection.py
@@ -19,7 +19,7 @@ def test_cross_validate():
             TorchDeviceMixin.__init__(self, device=device)
             _, _ = x, y
 
-        def _fit(self, x, y):
+        def _fit(self, x, y, validation_data=None):
             pass
 
         def _predict(self, x, with_grad=False):

--- a/tests/emulators/test_conformal.py
+++ b/tests/emulators/test_conformal.py
@@ -1,0 +1,31 @@
+import torch
+from autoemulate.core.types import DistributionLike, TensorLike
+from autoemulate.emulators.conformal import ConformalMLP
+
+
+def test_conformal_mlp():
+    def f(x):
+        return torch.sin(x)
+
+    # Training data
+    x_train = torch.rand(100, 3) * 10
+    y_train = f(x_train)
+
+    # Calibration data
+    x_cal, y_cal = torch.rand(100, 3) * 10, f(torch.rand(100, 3) * 10)
+
+    emulator = ConformalMLP(x_train, y_train, layer_dims=[100, 100], lr=1e-2)
+    emulator.fit(x_train, y_train, validation_data=(x_cal, y_cal))
+
+    # Test
+    x_test = torch.linspace(0.0, 15.0, steps=1000).repeat(1, 3).reshape(-1, 3)
+    y_test_hat = emulator.predict(x_test)
+    assert isinstance(y_test_hat, DistributionLike)
+    assert isinstance(y_test_hat.mean, TensorLike)
+    assert isinstance(y_test_hat.variance, TensorLike)
+    assert y_test_hat.mean.shape == (1000, 3)
+    assert y_test_hat.variance.shape == (1000, 3)
+    assert not y_test_hat.mean.requires_grad
+
+    y_test_hat_grad = emulator.predict(x_test, with_grad=True)
+    assert y_test_hat_grad.mean.requires_grad  # type: ignore  # noqa: PGH003

--- a/tests/emulators/test_conformal.py
+++ b/tests/emulators/test_conformal.py
@@ -29,3 +29,113 @@ def test_conformal_mlp():
 
     y_test_hat_grad = emulator.predict(x_test, with_grad=True)
     assert y_test_hat_grad.mean.requires_grad  # type: ignore  # noqa: PGH003
+
+
+def test_conformal_mlp_quantile_method():
+    """Test Conformalized Quantile Regression (CQR) method."""
+
+    def f(x):
+        return torch.sin(x)
+
+    # Training data
+    x_train = torch.rand(100, 3) * 10
+    y_train = f(x_train)
+
+    # Calibration data
+    x_cal, y_cal = torch.rand(100, 3) * 10, f(torch.rand(100, 3) * 10)
+
+    emulator = ConformalMLP(
+        x_train,
+        y_train,
+        method="quantile",
+        layer_dims=[100, 100],
+        lr=1e-2,
+        epochs=50,
+        quantile_emulator_kwargs={"epochs": 50, "lr": 1e-2},
+    )
+    emulator.fit(x_train, y_train, validation_data=(x_cal, y_cal))
+
+    # Test
+    x_test = torch.linspace(0.0, 15.0, steps=100).repeat(1, 3).reshape(-1, 3)
+    y_test_hat = emulator.predict(x_test)
+    assert isinstance(y_test_hat, DistributionLike)
+    assert isinstance(y_test_hat.mean, TensorLike)
+    assert isinstance(y_test_hat.variance, TensorLike)
+    assert y_test_hat.mean.shape == (100, 3)
+    assert y_test_hat.variance.shape == (100, 3)
+    assert not y_test_hat.mean.requires_grad
+
+    # Check that intervals vary across input space (not constant width)
+    interval_widths = y_test_hat.variance.sqrt() * 2  # approximate width
+    # Variance should differ across inputs for quantile method
+    assert interval_widths.std() > 0, "Intervals should vary across input space"
+
+
+def test_conformal_methods_comparison():
+    """Compare split vs quantile conformal methods on heteroscedastic data."""
+
+    def heteroscedastic_function(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Function with heteroscedastic noise (variance depends on x)."""
+        mean = torch.sin(2 * x)
+        # Variance increases with x
+        noise_std = 0.1 + 0.3 * (x / 10.0).abs()
+        noise = torch.randn_like(mean) * noise_std
+        return mean, mean + noise
+
+    # Generate training data with heteroscedastic noise
+    torch.manual_seed(42)
+    x_train = torch.rand(100, 1) * 10 - 5
+    _, y_train = heteroscedastic_function(x_train)
+
+    # Generate calibration data
+    x_cal = torch.rand(50, 1) * 10 - 5
+    _, y_cal = heteroscedastic_function(x_cal)
+
+    # Generate test data
+    x_test = torch.linspace(-5, 5, 50).reshape(-1, 1)
+
+    # Test split method
+    model_split = ConformalMLP(
+        x_train,
+        y_train,
+        method="split",
+        alpha=0.90,
+        layer_dims=[32, 16],
+        epochs=50,
+        lr=1e-2,
+    )
+    model_split.fit(x_train, y_train, validation_data=(x_cal, y_cal))
+    pred_split = model_split.predict(x_test)
+
+    # Test quantile method
+    model_quantile = ConformalMLP(
+        x_train,
+        y_train,
+        method="quantile",
+        alpha=0.90,
+        layer_dims=[32, 16],
+        epochs=50,
+        lr=1e-2,
+        quantile_emulator_kwargs={"epochs": 50, "lr": 1e-2},
+    )
+    model_quantile.fit(x_train, y_train, validation_data=(x_cal, y_cal))
+    pred_quantile = model_quantile.predict(x_test, with_grad=False)
+
+    # Compare interval widths
+    with torch.no_grad():
+        # Uniform distribution bounds provide interval limits directly
+        split_base = pred_split.base_dist  # type: ignore[attr-defined]
+        quantile_base = pred_quantile.base_dist  # type: ignore[attr-defined]
+
+        width_split = (split_base.high - split_base.low).squeeze()
+        width_quantile = (quantile_base.high - quantile_base.low).squeeze()
+
+    # Split conformal should have more uniform widths
+    # Quantile conformal should have more variable widths
+    assert width_quantile.std() >= width_split.std(), (
+        "Quantile method should have more variable interval widths"
+    )
+
+    # Both methods should produce valid predictions
+    assert pred_split.mean.shape == x_test.shape  # type: ignore[attr-defined]
+    assert pred_quantile.mean.shape == x_test.shape  # type: ignore[attr-defined]

--- a/tests/emulators/test_conformal.py
+++ b/tests/emulators/test_conformal.py
@@ -74,7 +74,7 @@ def test_conformal_mlp_quantile_method():
 def test_conformal_methods_comparison():
     """Compare split vs quantile conformal methods on heteroscedastic data."""
 
-    def heteroscedastic_function(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def heteroscedastic_function(x: TensorLike) -> tuple[TensorLike, TensorLike]:
         """Function with heteroscedastic noise (variance depends on x)."""
         mean = torch.sin(2 * x)
         # Variance increases with x

--- a/tests/emulators/test_conformal.py
+++ b/tests/emulators/test_conformal.py
@@ -119,7 +119,7 @@ def test_conformal_methods_comparison():
         quantile_emulator_kwargs={"epochs": 50, "lr": 1e-2},
     )
     model_quantile.fit(x_train, y_train, validation_data=(x_cal, y_cal))
-    pred_quantile = model_quantile.predict(x_test, with_grad=False)
+    pred_quantile = model_quantile.predict(x_test)
 
     # Compare interval widths
     with torch.no_grad():
@@ -130,10 +130,12 @@ def test_conformal_methods_comparison():
         width_split = (split_base.high - split_base.low).squeeze()
         width_quantile = (quantile_base.high - quantile_base.low).squeeze()
 
-    # Split conformal should have more uniform widths
-    # Quantile conformal should have more variable widths
-    assert width_quantile.std() >= width_split.std(), (
-        "Quantile method should have more variable interval widths"
+    # Split conformal should have constant widths (std ≈ 0)
+    assert width_split.std() < 1e-6, "Split method should have constant interval widths"
+
+    # Quantile conformal should have variable widths (std > 0)
+    assert width_quantile.std() > 0, (
+        "Quantile method should have variable interval widths"
     )
 
     # Both methods should produce valid predictions

--- a/tests/emulators/test_mlp.py
+++ b/tests/emulators/test_mlp.py
@@ -71,9 +71,9 @@ def test_mlp_predict_deterministic_with_seed(sample_data_y2d, new_data_y2d):
     model3.fit(x, y)
     pred3 = model3.predict(x2)
 
-    assert isinstance(pred1, torch.Tensor)
-    assert isinstance(pred2, torch.Tensor)
-    assert isinstance(pred3, torch.Tensor)
+    assert isinstance(pred1, TensorLike)
+    assert isinstance(pred2, TensorLike)
+    assert isinstance(pred3, TensorLike)
     assert torch.allclose(pred1, pred2)
     msg = "Predictions should differ with different seeds."
     assert not torch.allclose(pred1, pred3), msg


### PR DESCRIPTION
Closes #848.
Contributes towards #589.
(merge after #917)

This PR:
- Updates the base emulator API to enable the specification of validation data (to be used here as calibration data) (#905)
- Adds a base class wrapper for emulators to provide conformal prediction (analogous to `Ensemble`)
- Adds a `ConformalMLP` class (analogous to `EnsembleMLP`). This supports both constant width and quantile regression derived UQ.
- The quantile regression version uses an MLP with a quantile training loss to fit the upper and lower quantiles and then uses a constant per-target correction based on performance on the calibration training data
- Adds `ConformalMLP` to registry and re-exports (not adding as default emulator)
- Updates API to support passing `n_samples` - this is to enable this to be controlled at lower levels of the API from the high-level `AutoEmulate`.
- Adds `output_to_tensors` method on `ConversionMixin` to avoid repeated mapping of outputs to tensors
- Fixes indentation of docstrings in MLP subclasses

Question:
- Currently the two methods for deriving the intervals are part of the same base class with a parameter passed as a keyword argument - this is similar to the way the kernel fn is passed for GPs. Would it be preferable to have two classes? Or perhaps a general emulator subclass factory extending the one currently that only supports GPs.

Next steps:
- [x] Tests for passing validation data
- [x] Check UQ performance of `ConformalMLP` (e.g. on projectile and other simulators)
  - [x] For projectile "split" constant-width intervals does not provide good UQ while "quantile" is an improvement but less good than e.g. a GP.