### PR TITLE
Make loss_history instance variable (not class variable)

### DIFF
--- a/autoemulate/emulators/base.py
+++ b/autoemulate/emulators/base.py
@@ -1,6 +1,5 @@
 import random
 from abc import ABC, abstractmethod
-from typing import ClassVar
 
 import numpy as np
 import torch
@@ -545,7 +544,6 @@ class PyTorchBackend(nn.Module, Emulator):
     batch_size: int = 16
     shuffle: bool = True
     epochs: int = 10
-    loss_history: ClassVar[list[float]] = []
     verbose: bool = False
     loss_fn: nn.Module = nn.MSELoss()
     optimizer_cls: type[optim.Optimizer] = optim.Adam
@@ -570,6 +568,8 @@ class PyTorchBackend(nn.Module, Emulator):
         y: OutputLike or None
             Target values (not needed if x is a DataLoader).
         """
+        self.loss_history: list[float] = []
+
         self.train()  # Set model to training mode
 
         # Convert input to DataLoader if not already


### PR DESCRIPTION
When reviewing #939, I realised that we treat loss history as a class variable. This meant that when I train 5 PyTorch emulators, they all share the same loss history list appending to it. This PR changes it to an instance variable so that each emulator only stores its own loss history.