### PR TITLE
fixed class name

### DIFF
--- a/docs/tutorials/simulator/02_active_learning.ipynb
+++ b/docs/tutorials/simulator/02_active_learning.ipynb
@@ -179,7 +179,7 @@
     "1. **Training** – Fit the emulator on a batch of input-output pairs.\n",
     "2. **Prediction** – Generate output predictions (with uncertainty estimates) for new inputs.\n",
     "\n",
-    "In this example, we use a simple **Gaussian Process** model (`GaussianProcessExact`) provided by the AutoEmulate package."
+    "In this example, we use a simple **Gaussian Process** model (`GaussianProcessRBF`) provided by the AutoEmulate package."
    ]
   },
   {


### PR DESCRIPTION
I noticed the name of the class in the active learning tutorial may be wrong