### PR TITLE
Fix MLP docstring tests

### DIFF
--- a/tests/emulators/test_mlp.py
+++ b/tests/emulators/test_mlp.py
@@ -116,6 +116,8 @@ def test_mlp_docstring_no_additional():
         Number of parameters to predict per output dimension. Defaults to 1.
     random_seed: int | None
         Random seed for reproducibility. If None, no seed is set. Defaults to None.
+    deterministic: bool
+        Whether to use deterministic algorithms in PyTorch. Defaults to False.
     device: DeviceLike | None
         Device to run the model on (e.g., "cpu", "cuda", "mps"). Defaults to None.
     scheduler_cls: type[LRScheduler] | None
@@ -170,6 +172,8 @@ def test_mlp_docstring_with_args():
         Number of parameters to predict per output dimension. Defaults to 1.
     random_seed: int | None
         Random seed for reproducibility. If None, no seed is set. Defaults to None.
+    deterministic: bool
+        Whether to use deterministic algorithms in PyTorch. Defaults to False.
     device: DeviceLike | None
         Device to run the model on (e.g., "cpu", "cuda", "mps"). Defaults to None.
     scheduler_cls: type[LRScheduler] | None


### PR DESCRIPTION
This pull request updates the docstring checks in the MLP emulator tests to include the new `deterministic` parameter. The main change is ensuring that the docstrings for the MLP class now document the `deterministic` argument, including its type and default value.

Docstring updates:

* Both `test_mlp_docstring_no_additional` and `test_mlp_docstring_with_args` in `tests/emulators/test_mlp.py` were updated to check for the presence and description of the `deterministic` parameter in the MLP docstring. [[1]](diffhunk://#diff-5b0e34815d961c8309c28f6ed20346e0395ba8ac6490ca06fcd253712e00960cR119-R120) [[2]](diffhunk://#diff-5b0e34815d961c8309c28f6ed20346e0395ba8ac6490ca06fcd253712e00960cR175-R176)