### PR TITLE
Fix warnings in tests and revise `make_positive_definite`

### DIFF
--- a/autoemulate/calibration/bayes.py
+++ b/autoemulate/calibration/bayes.py
@@ -190,8 +190,9 @@ class BayesianCalibration(TorchDeviceMixin, BayesianMixin):
             total_variance = (
                 observation_variance + self.model_discrepancy + variance[0, i]
                 if self.model_uncertainty and variance is not None
-                else torch.tensor(observation_variance + self.model_discrepancy).to(
-                    self.device
+                else torch.as_tensor(
+                    observation_variance + self.model_discrepancy,
+                    device=self.device,
                 )
             )
             # Take sqrt for final scale (stddev)

--- a/autoemulate/transforms/utils.py
+++ b/autoemulate/transforms/utils.py
@@ -11,11 +11,15 @@ def make_positive_definite(
     Ensure a covariance matrix is positive definite.
 
     Ensure a covariance matrix is positive definite by:
-        1. adding increasing amounts of jitter to the diagonal and symmetrizing
-           the matrix
-        2. if this fails, clamping eigenvalues to a minimum value
-        3. if this still fails, clamping eigenvalues to both minimum and maximum
+        1. symmetrizing the matrix
+        2. adding increasing amounts of jitter to the diagonal
+        3. if this fails, clamping eigenvalues to a minimum value
+        4. if this still fails, clamping eigenvalues to both minimum and maximum
            values based on the median eigenvalue
+
+    The baseline jitter repair is silent because it is expected for numerically
+    semidefinite covariance estimates such as zero ensemble variance. Larger
+    repairs and eigenvalue clamping still warn.
 
     See related function in linear_operator: `psd_safe_cholesky`:
     https://github.com/cornellius-gp/linear_operator/blob/dca438e47dd8a380d0f4e6b30c406e187062c8bd/linear_operator/utils/cholesky.py#L12
@@ -37,7 +41,7 @@ def make_positive_definite(
     Returns
     -------
     torch.Tensor
-        A positive definite covariance matrix of the same shape as input.
+        A positive definite covariance matrix of the same shape as the input.
 
     Raises
     ------
@@ -46,33 +50,39 @@ def make_positive_definite(
     RuntimeError
         If the matrix cannot be made positive definite after all attempts.
     """
-    # If already positive definite, return as is
+    if cov.ndim not in (2, 3):
+        msg = f"cov must be a 2D or 3D tensor, got shape {tuple(cov.shape)}"
+        raise ValueError(msg)
+
+    # If already positive definite, return as is.
     try:
         torch.linalg.cholesky(cov)
         return cov
     except RuntimeError:
         pass
 
-    # If that fails, try adding increasing amounts of jitter
+    eye = torch.eye(cov.shape[-1], device=cov.device, dtype=cov.dtype)
+    if len(cov.shape) == 3:
+        eye = eye.unsqueeze(0)
+
+    # Symmetrize first. This is a cheap, silent repair for small numerical
+    # asymmetries and keeps the subsequent diagonal jitter symmetric.
+    cov = (cov + cov.transpose(-1, -2)) / 2
+
+    # If that fails, try adding increasing amounts of jitter.
     jitter = min_jitter
     for i in range(max_tries):
-        # Add jitter to diagonal and ensure symmetry
-        eye = torch.eye(cov.shape[-1], device=cov.device, dtype=cov.dtype)
-        if len(cov.shape) == 3:
-            eye = eye.unsqueeze(0)
-        if len(cov.shape) > 3:
-            msg = f"cov must be a 2D or 3D tensor, got shape {cov.shape}"
-            raise ValueError(msg) from None
         cov = cov + jitter * eye
-        cov = (cov + cov.transpose(-1, -2)) / 2
 
         try:
             torch.linalg.cholesky(cov)
-            warnings.warn(
-                f"cov not p.d. - added {jitter:.1e} to the diagonal and symmetrized",
-                NumericalWarning,
-                stacklevel=2,
-            )
+            if i > 0:
+                warnings.warn(
+                    f"cov not p.d. - added {jitter:.1e} to the diagonal and "
+                    "symmetrized",
+                    NumericalWarning,
+                    stacklevel=2,
+                )
             return cov
         except RuntimeError as e:
             if i == max_tries - 1 and not clamp_eigvals:
@@ -81,16 +91,15 @@ def make_positive_definite(
                     f"{max_tries} attempts with jitter up to {jitter:.1e}:\n{cov}"
                 )
                 raise RuntimeError(msg) from e
-            # Increase jitter for next attempt
+            # Increase jitter for next attempt.
             jitter *= 10
 
     # If adding jitter fails, optionally clamp eigvals to find closest positive definite
     # matrix using heuristic for upper bound of eigenvalues if clamping lower bound is
-    # not sufficient
+    # not sufficient.
     MIN_EIGVAL = 1e-3
     if clamp_eigvals:
-        # Attempt to first only clamp minimum eigenvals
-        cov = (cov + cov.transpose(-1, -2)) / 2
+        # Attempt to first only clamp minimum eigenvals.
         eigvals, eigvecs = torch.linalg.eigh(cov)
         eigvals = torch.clamp(eigvals, min=MIN_EIGVAL)
         cov = eigvecs @ torch.diag_embed(eigvals) @ eigvecs.transpose(-1, -2)
@@ -99,21 +108,22 @@ def make_positive_definite(
             torch.linalg.cholesky(cov)
             warnings.warn(
                 f"cov not p.d. - clamped min eigval to {MIN_EIGVAL:.1e} and "
-                "symmetrized",
+                "symmetrized; eigenvalue clamping can invalidate gradients through "
+                "the repaired covariance",
                 NumericalWarning,
                 stacklevel=2,
             )
             return cov
         except RuntimeError:
-            # Clamp both minimum and maximum eigvals
+            # Clamp both minimum and maximum eigvals.
             cov = (cov + cov.transpose(-1, -2)) / 2
             eigvals, eigvecs = torch.linalg.eigh(cov)
 
-            # Ensure condition number around 10**6
+            # Ensure condition number around 10**6.
             min_eigval = max(torch.min(eigvals).item(), MIN_EIGVAL)
             max_eigval = min(torch.max(eigvals).item(), 1e6 * min_eigval)
 
-            # Clamp eigvals
+            # Clamp eigvals.
             eigvals = torch.clamp(eigvals, min=min_eigval, max=max_eigval)
             cov = eigvecs @ torch.diag_embed(eigvals) @ eigvecs.transpose(-1, -2)
             cov = (cov + cov.transpose(-1, -2)) / 2
@@ -121,7 +131,8 @@ def make_positive_definite(
                 torch.linalg.cholesky(cov)
                 warnings.warn(
                     f"cov not p.d. - clamped min eigval to {min_eigval:.1e} and max "
-                    f"eigval to {max_eigval:.1e}, then symmetrized",
+                    f"eigval to {max_eigval:.1e}, then symmetrized; eigenvalue "
+                    "clamping can invalidate gradients through the repaired covariance",
                     NumericalWarning,
                     stacklevel=2,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ filterwarnings = [
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    # PyTorch MPS backend capability fallbacks are backend noise in tests.
+    "ignore:The operator .* is not currently supported on the MPS backend.*:UserWarning",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,10 @@ source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=v0"
+filterwarnings = [
+    "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
+]
 
 [tool.pyright]
 venvPath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,14 @@ source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=v0"
+# These suppress only test output; runtime warnings still reach users.
 filterwarnings = [
+    # Raised by PyTorch (via gpytorch) - not actionable here.
+    # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    # Expected output of `autoemulate.transforms.utils.make_positive_definite`
+    # when it repairs an ill-conditioned covariance; emitted across many GP,
+    # ensemble and transformed-emulator tests, so it is filtered globally.
     "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,10 +119,6 @@ filterwarnings = [
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
-    # Expected output of `autoemulate.transforms.utils.make_positive_definite`
-    # when it repairs an ill-conditioned covariance; emitted across many GP,
-    # ensemble and transformed-emulator tests, so it is filtered globally.
-    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
 ]
 
 [tool.pyright]

--- a/tests/emulators/test_grads.py
+++ b/tests/emulators/test_grads.py
@@ -9,6 +9,7 @@ from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms.pca import PCATransform
 from autoemulate.transforms.standardize import StandardizeTransform
 from autoemulate.transforms.vae import VAETransform
+from tests.utils import transformed_full_covariance_warning_context
 
 X_TRANSFORMS = [[StandardizeTransform()]]
 Y_TRANSFORMS = [
@@ -100,7 +101,11 @@ def test_grads(
     em.fit(x, y)
 
     # Get predictions
-    mean, variance = em.predict_mean_and_variance(x2, with_grad=True)
+    warning_context = transformed_full_covariance_warning_context(
+        output_from_samples, full_covariance, y_transforms
+    )
+    with warning_context:
+        mean, variance = em.predict_mean_and_variance(x2, with_grad=True)
 
     # Check that mean requires gradients
     assert mean.requires_grad

--- a/tests/emulators/test_transformed.py
+++ b/tests/emulators/test_transformed.py
@@ -1,6 +1,4 @@
 import itertools
-import warnings
-from contextlib import contextmanager, nullcontext
 
 import pytest
 import torch
@@ -12,30 +10,9 @@ from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms import PCATransform, StandardizeTransform, VAETransform
 from autoemulate.transforms.base import AutoEmulateTransform
-from linear_operator.utils.warnings import NumericalWarning
-
-
-@contextmanager
-def _ignore_expected_psd_repairs():
-    """Ignore expected PSD repairs in transformed full-covariance tests."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"cov not p\.d\. - .*",
-            category=NumericalWarning,
-        )
-        yield
-
-
-def _prediction_warning_context(output_from_samples, full_covariance, y_transforms):
-    if (
-        full_covariance
-        and not output_from_samples
-        and y_transforms is not None
-        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
-    ):
-        return _ignore_expected_psd_repairs()
-    return nullcontext()
+from tests.utils import (
+    transformed_full_covariance_warning_context,
+)
 
 
 def get_pytest_param_yof(model, x_t, y_t, o, f):
@@ -108,7 +85,7 @@ def run_test(
     )
     em.fit(x, y)
 
-    warning_context = _prediction_warning_context(
+    warning_context = transformed_full_covariance_warning_context(
         output_from_samples, full_covariance, y_transforms
     )
     with warning_context:

--- a/tests/emulators/test_transformed.py
+++ b/tests/emulators/test_transformed.py
@@ -1,4 +1,6 @@
 import itertools
+import warnings
+from contextlib import contextmanager, nullcontext
 
 import pytest
 import torch
@@ -10,6 +12,30 @@ from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms import PCATransform, StandardizeTransform, VAETransform
 from autoemulate.transforms.base import AutoEmulateTransform
+from linear_operator.utils.warnings import NumericalWarning
+
+
+@contextmanager
+def _ignore_expected_psd_repairs():
+    """Ignore expected PSD repairs in transformed full-covariance tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cov not p\.d\. - .*",
+            category=NumericalWarning,
+        )
+        yield
+
+
+def _prediction_warning_context(output_from_samples, full_covariance, y_transforms):
+    if (
+        full_covariance
+        and not output_from_samples
+        and y_transforms is not None
+        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
+    ):
+        return _ignore_expected_psd_repairs()
+    return nullcontext()
 
 
 def get_pytest_param_yof(model, x_t, y_t, o, f):
@@ -81,49 +107,54 @@ def run_test(
         full_covariance=full_covariance,
     )
     em.fit(x, y)
-    y_pred = em.predict(x2)
-    if issubclass(model, ProbabilisticEmulator):
-        assert isinstance(y_pred, DistributionLike)
-        y_pred_mean = em.predict_mean(x2)
-        assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred_mean.requires_grad
-        y_pred_mean, y_pred_var = em.predict_mean_and_variance(x2)
-        assert isinstance(y_pred_var, TensorLike)
-        assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
-        assert y_pred_var.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred_mean.requires_grad
-        assert not y_pred_var.requires_grad
-    else:
-        assert isinstance(y_pred, TensorLike)
-        assert y_pred.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred.requires_grad
 
-    if not test_grads:
-        return
-
-    # Test gradient support only for few targets case
-    if em.supports_grad:
-        y_pred_grad = em.predict(x2, with_grad=True)
+    warning_context = _prediction_warning_context(
+        output_from_samples, full_covariance, y_transforms
+    )
+    with warning_context:
+        y_pred = em.predict(x2)
         if issubclass(model, ProbabilisticEmulator):
-            assert isinstance(y_pred_grad, DistributionLike)
-            y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
-            assert y_pred_grad_mean.requires_grad
-            y_pred_grad_mean, y_pred_grad_var = em.predict_mean_and_variance(
-                x2, with_grad=True
-            )
-            assert isinstance(y_pred_grad_var, TensorLike)
-            assert y_pred_grad_mean.requires_grad
-            assert y_pred_grad_var.requires_grad
+            assert isinstance(y_pred, DistributionLike)
+            y_pred_mean = em.predict_mean(x2)
+            assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred_mean.requires_grad
+            y_pred_mean, y_pred_var = em.predict_mean_and_variance(x2)
+            assert isinstance(y_pred_var, TensorLike)
+            assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
+            assert y_pred_var.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred_mean.requires_grad
+            assert not y_pred_var.requires_grad
         else:
-            assert isinstance(y_pred_grad, TensorLike)
-            assert y_pred_grad.requires_grad
-            y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
-            assert y_pred_grad_mean.requires_grad
-        return
+            assert isinstance(y_pred, TensorLike)
+            assert y_pred.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred.requires_grad
 
-    # Test that gradients raise error when not supported
-    with pytest.raises(ValueError, match="Gradient calculation is not supported."):
-        em.predict(x2, with_grad=True)
+        if not test_grads:
+            return
+
+        # Test gradient support only for few targets case
+        if em.supports_grad:
+            y_pred_grad = em.predict(x2, with_grad=True)
+            if issubclass(model, ProbabilisticEmulator):
+                assert isinstance(y_pred_grad, DistributionLike)
+                y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
+                assert y_pred_grad_mean.requires_grad
+                y_pred_grad_mean, y_pred_grad_var = em.predict_mean_and_variance(
+                    x2, with_grad=True
+                )
+                assert isinstance(y_pred_grad_var, TensorLike)
+                assert y_pred_grad_mean.requires_grad
+                assert y_pred_grad_var.requires_grad
+            else:
+                assert isinstance(y_pred_grad, TensorLike)
+                assert y_pred_grad.requires_grad
+                y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
+                assert y_pred_grad_mean.requires_grad
+            return
+
+        # Test that gradients raise error when not supported
+        with pytest.raises(ValueError, match="Gradient calculation is not supported."):
+            em.predict(x2, with_grad=True)
 
 
 @pytest.mark.parametrize(
@@ -264,6 +295,9 @@ def test_transformed_emulator_1000_targets(
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning"
+)
 def test_inverse_gaussian_and_sample_pca(sample_data_y2d, new_data_y2d):
     set_random_seed(0)
     x, y = sample_data_y2d
@@ -306,6 +340,9 @@ def test_inverse_gaussian_and_sample_pca(sample_data_y2d, new_data_y2d):
     assert torch.allclose(y_pred_cov, y_pred2_cov, rtol=5e-2)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning"
+)
 def test_inverse_gaussian_and_sample_vae(sample_data_y2d, new_data_y2d):
     torch.manual_seed(0)
     x, y = sample_data_y2d

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -233,6 +233,8 @@ def test_sample(method):
     }
     sim = MockSimulator(param_bouns, ["var1", "var2"])
 
+    # Sobol needs a power-of-two count to keep its balance properties (SciPy warns
+    # otherwise); other methods are unconstrained.
     n_samples = 1024 if method == "sobol" else 1000
     samples = sim.sample_inputs(n_samples, method=method)
 

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -233,7 +233,7 @@ def test_sample(method):
     }
     sim = MockSimulator(param_bouns, ["var1", "var2"])
 
-    n_samples = 1000
+    n_samples = 1024 if method == "sobol" else 1000
     samples = sim.sample_inputs(n_samples, method=method)
 
     assert isinstance(samples, TensorLike)

--- a/tests/transforms/test_transforms_utils.py
+++ b/tests/transforms/test_transforms_utils.py
@@ -1,19 +1,76 @@
+import warnings
+
 import pytest
 import torch
 from autoemulate.transforms.utils import make_positive_definite
+from linear_operator.utils.warnings import NumericalWarning
 
 
 @pytest.mark.parametrize("scale", [1e-6, 1.0, 1e6])
 def test_make_positive_definite(scale):
-    """Test that make_positive_definite can handle various cases of cov matrices."""
-
-    # Try large scale
+    """make_positive_definite handles a range of badly-scaled, non-p.d. matrices."""
     for dim in [5, 20, 100]:
-        # Batch of 1000 random covariance matrices
+        # Batch of 1000 random (non-symmetric, non-p.d.) matrices
         covs = torch.rand(1000, dim, dim) * scale
-        covs = make_positive_definite(covs, clamp_eigvals=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumericalWarning)
+            covs = make_positive_definite(covs, clamp_eigvals=True)
 
         for cov in covs:
             assert cov.shape == (dim, dim)
-            # Try cholesky decomposition to check if it's positive definite
+            # Cholesky decomposition succeeds iff the matrix is positive definite
             torch.linalg.cholesky(cov)
+
+
+def test_make_positive_definite_already_pd_is_unchanged():
+    """An already-p.d. matrix is returned untouched and without warnings."""
+    cov = torch.tensor([[2.0, 0.5], [0.5, 1.0]], dtype=torch.float64)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = make_positive_definite(cov)
+    assert out is cov
+
+
+def test_make_positive_definite_baseline_jitter_is_silent():
+    """Rounding-level non-p.d.-ness is repaired by the baseline jitter, silently."""
+    cov = torch.eye(4, dtype=torch.float64)
+    cov[0, 0] = -1e-10  # not p.d., but well within the baseline jitter
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = make_positive_definite(cov)
+    torch.linalg.cholesky(out)
+
+
+def test_make_positive_definite_material_jitter_warns_and_keeps_gradients():
+    """A material jitter warns; the result stays differentiable w.r.t. the input."""
+    x = torch.tensor(1.0, dtype=torch.float64, requires_grad=True)
+    # Diagonal with one (small) negative eigenvalue; the baseline jitter is too
+    # small to fix it, so the jitter has to escalate past it.
+    cov = torch.diag(torch.stack([x, -1e-5 * x]))
+    with pytest.warns(NumericalWarning, match="added"):
+        out = make_positive_definite(cov, max_tries=8)
+    torch.linalg.cholesky(out)
+    out.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad)
+
+
+def test_make_positive_definite_eigval_clamp_warns():
+    """The eigenvalue-clamping fallback warns."""
+    cov = torch.diag(torch.tensor([-1.0, 1.0, 1.0], dtype=torch.float64))
+    with pytest.warns(NumericalWarning, match="gradients"):
+        out = make_positive_definite(cov, clamp_eigvals=True)
+    torch.linalg.cholesky(out)
+
+
+def test_make_positive_definite_raises_without_clamp():
+    """Without eigenvalue clamping, an unrepairable matrix raises rather than warns."""
+    cov = torch.diag(torch.tensor([-1.0, 1.0, 1.0], dtype=torch.float64))
+    with pytest.raises(RuntimeError):
+        make_positive_definite(cov)
+
+
+def test_make_positive_definite_rejects_high_rank_tensors():
+    """Only 2D and 3D (batched) tensors are accepted."""
+    with pytest.raises(ValueError, match="2D or 3D"):
+        make_positive_definite(torch.zeros(2, 3, 3, 3))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,31 @@
+import warnings
+from contextlib import contextmanager, nullcontext
+
+from autoemulate.transforms import PCATransform, VAETransform
+from linear_operator.utils.warnings import NumericalWarning
+
+
+@contextmanager
+def ignore_expected_transformed_psd_repairs():
+    """Ignore expected PSD repairs in transformed full-covariance tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cov not p\.d\. - .*",
+            category=NumericalWarning,
+        )
+        yield
+
+
+def transformed_full_covariance_warning_context(
+    output_from_samples, full_covariance, y_transforms
+):
+    """Return a warning context for expected transformed covariance repairs."""
+    if (
+        full_covariance
+        and not output_from_samples
+        and y_transforms is not None
+        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
+    ):
+        return ignore_expected_transformed_psd_repairs()
+    return nullcontext()


### PR DESCRIPTION
Contributes towards #978.

This PR:
- Revises `make_positive_definite` utility for covariance matrices
- Ignores expected warnings raised during tests
- Applies fixes related to two warnings previously raised in tests

**Improvements to `make_positive_definite` utility:**

* Refactored the `make_positive_definite` function to first symmetrize the matrix before adding jitter, clarified the repair strategy in the docstring, improved error messages, and ensured only 2D/3D tensors are accepted. Baseline jitter repairs are now silent, while larger repairs and eigenvalue clamping issue warnings. [[1]](diffhunk://#diff-6e25e31d2fd0071b7317b3db46270c42838fccbe03d74007763e8fafe8997ad1L14-R23) [[2]](diffhunk://#diff-6e25e31d2fd0071b7317b3db46270c42838fccbe03d74007763e8fafe8997ad1L40-R44) [[3]](diffhunk://#diff-6e25e31d2fd0071b7317b3db46270c42838fccbe03d74007763e8fafe8997ad1L49-R82) [[4]](diffhunk://#diff-6e25e31d2fd0071b7317b3db46270c42838fccbe03d74007763e8fafe8997ad1L84-R102) [[5]](diffhunk://#diff-6e25e31d2fd0071b7317b3db46270c42838fccbe03d74007763e8fafe8997ad1L102-R135)
* Added comprehensive tests for `make_positive_definite`, covering already positive-definite matrices, baseline and material jitter repairs, eigenvalue clamping, error cases, and input validation.

**Test infrastructure and warning handling:**

* Introduced utilities (`transformed_full_covariance_warning_context` and `ignore_expected_transformed_psd_repairs`) to selectively suppress or handle expected numerical warnings in tests involving transformed outputs.
* Updated relevant tests in `test_grads.py` and `test_transformed.py` to use the new warning context utilities, ensuring that expected warnings do not cause test failures. [[1]](diffhunk://#diff-10b417dbc77d0e5830e5d4ebd71a2bfc877a3451ffa51e3f3e41299c34ca59c3R12) [[2]](diffhunk://#diff-10b417dbc77d0e5830e5d4ebd71a2bfc877a3451ffa51e3f3e41299c34ca59c3R104-R107) [[3]](diffhunk://#diff-4bf6ee1ee467058fc62975d2a0e934420652a6125261d5c2e9288dc72cbddb1bR13-R15) [[4]](diffhunk://#diff-4bf6ee1ee467058fc62975d2a0e934420652a6125261d5c2e9288dc72cbddb1bR87-R91)
* Added targeted warning filters to `pytest` configuration to suppress noisy or non-actionable warnings from dependencies during test runs.
* Marked specific tests with `pytest.mark.filterwarnings` to ignore known numerical warnings during covariance repairs. [[1]](diffhunk://#diff-4bf6ee1ee467058fc62975d2a0e934420652a6125261d5c2e9288dc72cbddb1bR275-R277) [[2]](diffhunk://#diff-4bf6ee1ee467058fc62975d2a0e934420652a6125261d5c2e9288dc72cbddb1bR320-R322)

**Miscellaneous:**

* Adjusted sample size in `test_base_simulator.py` to ensure Sobol sampling uses a power-of-two count, avoiding SciPy warnings.
* Minor improvement to tensor creation in `bayes.py` for device consistency.