### PR TITLE
Fix slow calibration tests

### DIFF
--- a/autoemulate/calibration/bayes.py
+++ b/autoemulate/calibration/bayes.py
@@ -190,8 +190,9 @@ class BayesianCalibration(TorchDeviceMixin, BayesianMixin):
             total_variance = (
                 observation_variance + self.model_discrepancy + variance[0, i]
                 if self.model_uncertainty and variance is not None
-                else torch.tensor(observation_variance + self.model_discrepancy).to(
-                    self.device
+                else torch.as_tensor(
+                    observation_variance + self.model_discrepancy,
+                    device=self.device,
                 )
             )
             # Take sqrt for final scale (stddev)

--- a/autoemulate/transforms/utils.py
+++ b/autoemulate/transforms/utils.py
@@ -11,11 +11,15 @@ def make_positive_definite(
     Ensure a covariance matrix is positive definite.
 
     Ensure a covariance matrix is positive definite by:
-        1. adding increasing amounts of jitter to the diagonal and symmetrizing
-           the matrix
-        2. if this fails, clamping eigenvalues to a minimum value
-        3. if this still fails, clamping eigenvalues to both minimum and maximum
+        1. symmetrizing the matrix
+        2. adding increasing amounts of jitter to the diagonal
+        3. if this fails, clamping eigenvalues to a minimum value
+        4. if this still fails, clamping eigenvalues to both minimum and maximum
            values based on the median eigenvalue
+
+    The baseline jitter repair is silent because it is expected for numerically
+    semidefinite covariance estimates such as zero ensemble variance. Larger
+    repairs and eigenvalue clamping still warn.
 
     See related function in linear_operator: `psd_safe_cholesky`:
     https://github.com/cornellius-gp/linear_operator/blob/dca438e47dd8a380d0f4e6b30c406e187062c8bd/linear_operator/utils/cholesky.py#L12
@@ -37,7 +41,7 @@ def make_positive_definite(
     Returns
     -------
     torch.Tensor
-        A positive definite covariance matrix of the same shape as input.
+        A positive definite covariance matrix of the same shape as the input.
 
     Raises
     ------
@@ -46,33 +50,39 @@ def make_positive_definite(
     RuntimeError
         If the matrix cannot be made positive definite after all attempts.
     """
-    # If already positive definite, return as is
+    if cov.ndim not in (2, 3):
+        msg = f"cov must be a 2D or 3D tensor, got shape {tuple(cov.shape)}"
+        raise ValueError(msg)
+
+    # If already positive definite, return as is.
     try:
         torch.linalg.cholesky(cov)
         return cov
     except RuntimeError:
         pass
 
-    # If that fails, try adding increasing amounts of jitter
+    eye = torch.eye(cov.shape[-1], device=cov.device, dtype=cov.dtype)
+    if len(cov.shape) == 3:
+        eye = eye.unsqueeze(0)
+
+    # Symmetrize first. This is a cheap, silent repair for small numerical
+    # asymmetries and keeps the subsequent diagonal jitter symmetric.
+    cov = (cov + cov.transpose(-1, -2)) / 2
+
+    # If that fails, try adding increasing amounts of jitter.
     jitter = min_jitter
     for i in range(max_tries):
-        # Add jitter to diagonal and ensure symmetry
-        eye = torch.eye(cov.shape[-1], device=cov.device, dtype=cov.dtype)
-        if len(cov.shape) == 3:
-            eye = eye.unsqueeze(0)
-        if len(cov.shape) > 3:
-            msg = f"cov must be a 2D or 3D tensor, got shape {cov.shape}"
-            raise ValueError(msg) from None
         cov = cov + jitter * eye
-        cov = (cov + cov.transpose(-1, -2)) / 2
 
         try:
             torch.linalg.cholesky(cov)
-            warnings.warn(
-                f"cov not p.d. - added {jitter:.1e} to the diagonal and symmetrized",
-                NumericalWarning,
-                stacklevel=2,
-            )
+            if i > 0:
+                warnings.warn(
+                    f"cov not p.d. - added {jitter:.1e} to the diagonal and "
+                    "symmetrized",
+                    NumericalWarning,
+                    stacklevel=2,
+                )
             return cov
         except RuntimeError as e:
             if i == max_tries - 1 and not clamp_eigvals:
@@ -81,16 +91,15 @@ def make_positive_definite(
                     f"{max_tries} attempts with jitter up to {jitter:.1e}:\n{cov}"
                 )
                 raise RuntimeError(msg) from e
-            # Increase jitter for next attempt
+            # Increase jitter for next attempt.
             jitter *= 10
 
     # If adding jitter fails, optionally clamp eigvals to find closest positive definite
     # matrix using heuristic for upper bound of eigenvalues if clamping lower bound is
-    # not sufficient
+    # not sufficient.
     MIN_EIGVAL = 1e-3
     if clamp_eigvals:
-        # Attempt to first only clamp minimum eigenvals
-        cov = (cov + cov.transpose(-1, -2)) / 2
+        # Attempt to first only clamp minimum eigenvals.
         eigvals, eigvecs = torch.linalg.eigh(cov)
         eigvals = torch.clamp(eigvals, min=MIN_EIGVAL)
         cov = eigvecs @ torch.diag_embed(eigvals) @ eigvecs.transpose(-1, -2)
@@ -99,21 +108,22 @@ def make_positive_definite(
             torch.linalg.cholesky(cov)
             warnings.warn(
                 f"cov not p.d. - clamped min eigval to {MIN_EIGVAL:.1e} and "
-                "symmetrized",
+                "symmetrized; eigenvalue clamping can invalidate gradients through "
+                "the repaired covariance",
                 NumericalWarning,
                 stacklevel=2,
             )
             return cov
         except RuntimeError:
-            # Clamp both minimum and maximum eigvals
+            # Clamp both minimum and maximum eigvals.
             cov = (cov + cov.transpose(-1, -2)) / 2
             eigvals, eigvecs = torch.linalg.eigh(cov)
 
-            # Ensure condition number around 10**6
+            # Ensure condition number around 10**6.
             min_eigval = max(torch.min(eigvals).item(), MIN_EIGVAL)
             max_eigval = min(torch.max(eigvals).item(), 1e6 * min_eigval)
 
-            # Clamp eigvals
+            # Clamp eigvals.
             eigvals = torch.clamp(eigvals, min=min_eigval, max=max_eigval)
             cov = eigvecs @ torch.diag_embed(eigvals) @ eigvecs.transpose(-1, -2)
             cov = (cov + cov.transpose(-1, -2)) / 2
@@ -121,7 +131,8 @@ def make_positive_definite(
                 torch.linalg.cholesky(cov)
                 warnings.warn(
                     f"cov not p.d. - clamped min eigval to {min_eigval:.1e} and max "
-                    f"eigval to {max_eigval:.1e}, then symmetrized",
+                    f"eigval to {max_eigval:.1e}, then symmetrized; eigenvalue "
+                    "clamping can invalidate gradients through the repaired covariance",
                     NumericalWarning,
                     stacklevel=2,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,8 @@ filterwarnings = [
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    # PyTorch MPS backend capability fallbacks are backend noise in tests.
+    "ignore:The operator .* is not currently supported on the MPS backend.*:UserWarning",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,10 @@ source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=v0"
+filterwarnings = [
+    "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
+]
 
 [tool.pyright]
 venvPath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,14 @@ source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
 addopts = "--ignore=v0"
+# These suppress only test output; runtime warnings still reach users.
 filterwarnings = [
+    # Raised by PyTorch (via gpytorch) - not actionable here.
+    # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    # Expected output of `autoemulate.transforms.utils.make_positive_definite`
+    # when it repairs an ill-conditioned covariance; emitted across many GP,
+    # ensemble and transformed-emulator tests, so it is filtered globally.
     "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,10 +119,6 @@ filterwarnings = [
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
-    # Expected output of `autoemulate.transforms.utils.make_positive_definite`
-    # when it repairs an ill-conditioned covariance; emitted across many GP,
-    # ensemble and transformed-emulator tests, so it is filtered globally.
-    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning",
 ]
 
 [tool.pyright]

--- a/tests/calibration/test_bayesian_calibration.py
+++ b/tests/calibration/test_bayesian_calibration.py
@@ -1,33 +1,64 @@
+import pyro
 import pytest
 from autoemulate.calibration.bayes import BayesianCalibration
 from autoemulate.core.types import TensorLike
 from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.simulations.projectile import Projectile, ProjectileMultioutput
 
+N_TRAINING_POINTS = 30
+N_MCMC_SAMPLES = 4
+N_MCMC_WARMUP = 3
+GP_EPOCHS = 5
+HMC_STEP_SIZE = 0.1
+HMC_TRAJECTORY_LENGTH = 0.1
+SINGLE_OUTPUT_HMC_CASES = [
+    (1, 1, False),
+    (10, 1, False),
+    (10, 2, True),
+]
+MULTI_OUTPUT_HMC_CASES = [
+    (1, 1, False),
+    (10, 1, True),
+]
+
+
+@pytest.fixture(scope="module")
+def projectile_calibration_setup():
+    """Train a small single-output emulator once for calibration tests."""
+    pyro.set_rng_seed(0)
+    sim = Projectile()
+    x = sim.sample_inputs(N_TRAINING_POINTS)
+    y, _ = sim.forward_batch(x)
+    assert isinstance(y, TensorLike)
+    gp = GaussianProcess(x, y, epochs=GP_EPOCHS)
+    gp.fit(x, y)
+    return sim, gp, y
+
+
+@pytest.fixture(scope="module")
+def projectile_multioutput_calibration_setup():
+    """Train a small multi-output emulator once for calibration tests."""
+    pyro.set_rng_seed(1)
+    sim = ProjectileMultioutput()
+    x = sim.sample_inputs(N_TRAINING_POINTS)
+    y, _ = sim.forward_batch(x)
+    assert isinstance(y, TensorLike)
+    gp = GaussianProcess(x, y, epochs=GP_EPOCHS)
+    gp.fit(x, y)
+    return sim, gp, y
+
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples", "model_uncertainty"),
-    [
-        (1, 1, 10, False),
-        (10, 1, 10, False),
-        (1, 2, 10, False),
-        (10, 2, 10, False),
-        (1, 1, 10, True),
-        (10, 1, 10, True),
-        (1, 2, 10, True),
-        (10, 2, 10, True),
-    ],
+    ("n_obs", "n_chains", "model_uncertainty"),
+    SINGLE_OUTPUT_HMC_CASES,
 )
-def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
+def test_hmc_single_output(
+    projectile_calibration_setup, n_obs, n_chains, model_uncertainty
+):
     """
     Test HMC with single output.
     """
-    sim = Projectile()
-    x = sim.sample_inputs(100)
-    y, _ = sim.forward_batch(x)
-    assert isinstance(y, TensorLike)
-    gp = GaussianProcess(x, y)
-    gp.fit(x, y)
+    sim, gp, y = projectile_calibration_setup
 
     # pick the first n_obs sim outputs as observations
     observations = {"distance": y[:n_obs, 0]}
@@ -37,14 +68,22 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
     assert bc.observation_noise == {"distance": 1.0}
 
     # check samples are generated
-    mcmc = bc.run_mcmc(warmup_steps=10, num_samples=n_samples, num_chains=n_chains)
+    pyro.set_rng_seed(100 + n_obs + n_chains + int(model_uncertainty))
+    mcmc = bc.run_mcmc(
+        warmup_steps=N_MCMC_WARMUP,
+        num_samples=N_MCMC_SAMPLES,
+        num_chains=n_chains,
+        sampler="hmc",
+        step_size=HMC_STEP_SIZE,
+        trajectory_length=HMC_TRAJECTORY_LENGTH,
+    )
     samples = mcmc.get_samples(group_by_chain=True)
     assert "c" in samples
     assert "v0" in samples
     assert samples["c"].shape[0] == n_chains
-    assert samples["c"].shape[1] == n_samples
+    assert samples["c"].shape[1] == N_MCMC_SAMPLES
     assert samples["v0"].shape[0] == n_chains
-    assert samples["v0"].shape[1] == n_samples
+    assert samples["v0"].shape[1] == N_MCMC_SAMPLES
 
     # posterior predictive
     pp = bc.posterior_predictive(mcmc)
@@ -52,33 +91,21 @@ def test_hmc_single_output(n_obs, n_chains, n_samples, model_uncertainty):
     pp = dict(pp)  # keeping type checker happy
     assert "distance" in pp
     # get a prediction per mcmc sample and observation
-    assert pp["distance"].shape[0] == n_samples * n_chains
+    assert pp["distance"].shape[0] == N_MCMC_SAMPLES * n_chains
     assert pp["distance"].shape[1] == n_obs
 
 
 @pytest.mark.parametrize(
-    ("n_obs", "n_chains", "n_samples", "model_uncertainty"),
-    [
-        (1, 1, 10, False),
-        (10, 1, 10, False),
-        (1, 2, 10, False),
-        (10, 2, 10, False),
-        (1, 1, 10, True),
-        (10, 1, 10, True),
-        (1, 2, 10, True),
-        (10, 2, 10, True),
-    ],
+    ("n_obs", "n_chains", "model_uncertainty"),
+    MULTI_OUTPUT_HMC_CASES,
 )
-def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
+def test_hmc_multiple_output(
+    projectile_multioutput_calibration_setup, n_obs, n_chains, model_uncertainty
+):
     """
     Test HMC with multiple outputs.
     """
-    sim = ProjectileMultioutput()
-    x = sim.sample_inputs(100)
-    y, _ = sim.forward_batch(x)
-    assert isinstance(y, TensorLike)
-    gp = GaussianProcess(x, y)
-    gp.fit(x, y)
+    sim, gp, y = projectile_multioutput_calibration_setup
 
     # pick the first n_obs sim outputs as observations
     observations = {
@@ -91,14 +118,22 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
     assert bc.observation_noise == {"distance": 1.0, "impact_velocity": 1.0}
 
     # check samples are generated
-    mcmc = bc.run_mcmc(warmup_steps=5, num_samples=n_samples, num_chains=n_chains)
+    pyro.set_rng_seed(200 + n_obs + n_chains + int(model_uncertainty))
+    mcmc = bc.run_mcmc(
+        warmup_steps=N_MCMC_WARMUP,
+        num_samples=N_MCMC_SAMPLES,
+        num_chains=n_chains,
+        sampler="hmc",
+        step_size=HMC_STEP_SIZE,
+        trajectory_length=HMC_TRAJECTORY_LENGTH,
+    )
     samples = mcmc.get_samples(group_by_chain=True)
     assert "c" in samples
     assert "v0" in samples
     assert samples["c"].shape[0] == n_chains
-    assert samples["c"].shape[1] == n_samples
+    assert samples["c"].shape[1] == N_MCMC_SAMPLES
     assert samples["v0"].shape[0] == n_chains
-    assert samples["v0"].shape[1] == n_samples
+    assert samples["v0"].shape[1] == N_MCMC_SAMPLES
 
     # posterior predictive
     pp = bc.posterior_predictive(mcmc)
@@ -107,7 +142,7 @@ def test_hmc_multiple_output(n_obs, n_chains, n_samples, model_uncertainty):
     assert "distance" in pp
     assert "impact_velocity" in pp
     # get a prediction per mcmc sample and observation
-    assert pp["distance"].shape[0] == n_samples * n_chains
+    assert pp["distance"].shape[0] == N_MCMC_SAMPLES * n_chains
     assert pp["distance"].shape[1] == n_obs
-    assert pp["impact_velocity"].shape[0] == n_samples * n_chains
+    assert pp["impact_velocity"].shape[0] == N_MCMC_SAMPLES * n_chains
     assert pp["impact_velocity"].shape[1] == n_obs

--- a/tests/calibration/test_evidence_computation.py
+++ b/tests/calibration/test_evidence_computation.py
@@ -9,35 +9,62 @@ from autoemulate.calibration.bayes import (
     extract_log_probabilities,
 )
 from autoemulate.calibration.evidence import EvidenceComputation
-from autoemulate.core.types import TensorLike
 from autoemulate.emulators.gaussian_process.exact import GaussianProcess
-from autoemulate.simulations.epidemic import Epidemic
 from autoemulate.simulations.projectile import Projectile
 from pyro.infer import MCMC
 from pyro.infer.mcmc import RandomWalkKernel
 
+N_TRAINING_POINTS = 30
+N_MCMC_CHAINS = 4
+N_MCMC_SAMPLES = 40
+N_INTEGRATION_MCMC_CHAINS = 2
+N_INTEGRATION_MCMC_SAMPLES = 4
+N_INTEGRATION_MCMC_WARMUP = 3
+N_FLOW_EPOCHS = 1
+GP_EPOCHS = 5
+HMC_STEP_SIZE = 0.1
+HMC_TRAJECTORY_LENGTH = 0.1
+TEST_FLOW_KWARGS = {
+    "n_layers": 2,
+    "n_bins": 8,
+    "hidden_size": [16, 16],
+}
 
-@pytest.fixture
+
+class SimpleMCMC:
+    """Minimal MCMC-like object exposing the Pyro get_samples interface."""
+
+    def __init__(self, samples):
+        self._samples = samples
+
+    def get_samples(self, group_by_chain=False):
+        if group_by_chain:
+            return self._samples
+        return {name: values.reshape(-1) for name, values in self._samples.items()}
+
+
+def simple_model():
+    """Small model with two parameters for evidence unit tests."""
+    c = pyro.sample("c", dist.Normal(0.0, 1.0))
+    v0 = pyro.sample("v0", dist.Normal(0.0, 1.0))
+    pyro.sample("obs", dist.Normal(c + v0, 1.0), obs=torch.tensor(0.25))
+
+
+def make_evidence_computation(mcmc, model, **kwargs):
+    kwargs.setdefault("flow_kwargs", TEST_FLOW_KWARGS)
+    kwargs.setdefault("log_level", "error")
+    return EvidenceComputation(mcmc, model, **kwargs)
+
+
+@pytest.fixture(scope="module")
 def simple_mcmc_setup():
-    """Create a simple MCMC setup for testing."""
-    sim = Epidemic(log_level="error")
-    x = sim.sample_inputs(50)
-    y, _ = sim.forward_batch(x)
-    assert isinstance(y, TensorLike)
-
-    gp = GaussianProcess(x, y)
-    gp.fit(x, y)
-
-    # Create observations
-    observations = {"distance": y[:5, 0]}
-    bc = BayesianCalibration(
-        gp, sim.parameters_range, observations, 1.0, log_level="error"
-    )
-
-    # Run MCMC with sufficient samples for evidence computation
-    mcmc = bc.run_mcmc(warmup_steps=50, num_samples=500, num_chains=10)
-
-    return mcmc, bc.model, sim
+    """Create deterministic posterior samples for evidence tests."""
+    generator = torch.Generator().manual_seed(0)
+    samples = {
+        "c": 0.4 * torch.randn(N_MCMC_CHAINS, N_MCMC_SAMPLES, generator=generator),
+        "v0": 0.4 * torch.randn(N_MCMC_CHAINS, N_MCMC_SAMPLES, generator=generator),
+    }
+    return SimpleMCMC(samples), simple_model, None
 
 
 class TestExtractLogProbabilities:
@@ -52,10 +79,10 @@ class TestExtractLogProbabilities:
         # Check shapes
         assert samples.ndim == 3  # (chains, samples_per_chain, ndim)
         assert log_probs.ndim == 2  # (chains, samples_per_chain)
-        assert samples.shape[0] == 10  # num_chains
-        assert samples.shape[1] == 500  # num_samples_per_chain
+        assert samples.shape[0] == N_MCMC_CHAINS
+        assert samples.shape[1] == N_MCMC_SAMPLES
         assert samples.shape[2] == 2  # num_parameters (c, v0)
-        assert log_probs.shape == (10, 500)
+        assert log_probs.shape == (N_MCMC_CHAINS, N_MCMC_SAMPLES)
 
     def test_log_probs_are_finite(self, simple_mcmc_setup):
         """Test that log probabilities are finite."""
@@ -107,7 +134,7 @@ class TestEvidenceComputation:
         """Test EvidenceComputation initialization."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(
+        ec = make_evidence_computation(
             mcmc, model, training_proportion=0.5, temperature=0.8, log_level="error"
         )
 
@@ -117,55 +144,55 @@ class TestEvidenceComputation:
         assert ec.temperature == 0.8
         assert ec.samples is not None
         assert ec.log_probs is not None
-        assert ec.samples.shape[0] == 10  # num_chains
-        assert ec.samples.shape[1] == 500  # num_samples_per_chain
+        assert ec.samples.shape[0] == N_MCMC_CHAINS
+        assert ec.samples.shape[1] == N_MCMC_SAMPLES
 
     def test_invalid_training_proportion(self, simple_mcmc_setup):
         """Test that invalid training_proportion raises ValueError."""
         mcmc, model, _ = simple_mcmc_setup
 
         with pytest.raises(ValueError, match="training_proportion must be between"):
-            EvidenceComputation(mcmc, model, training_proportion=0.0)
+            make_evidence_computation(mcmc, model, training_proportion=0.0)
 
         with pytest.raises(ValueError, match="training_proportion must be between"):
-            EvidenceComputation(mcmc, model, training_proportion=1.0)
+            make_evidence_computation(mcmc, model, training_proportion=1.0)
 
         with pytest.raises(ValueError, match="training_proportion must be between"):
-            EvidenceComputation(mcmc, model, training_proportion=-0.5)
+            make_evidence_computation(mcmc, model, training_proportion=-0.5)
 
     def test_invalid_temperature(self, simple_mcmc_setup):
         """Test that invalid temperature raises ValueError."""
         mcmc, model, _ = simple_mcmc_setup
 
         with pytest.raises(ValueError, match="temperature must be positive"):
-            EvidenceComputation(mcmc, model, temperature=0.0)
+            make_evidence_computation(mcmc, model, temperature=0.0)
 
         with pytest.raises(ValueError, match="temperature must be positive"):
-            EvidenceComputation(mcmc, model, temperature=-1.0)
+            make_evidence_computation(mcmc, model, temperature=-1.0)
 
     def test_unsupported_flow_model(self, simple_mcmc_setup):
         """Test that unsupported flow_model raises ValueError."""
         mcmc, model, _ = simple_mcmc_setup
 
         with pytest.raises(ValueError, match="Unsupported flow_model"):
-            EvidenceComputation(mcmc, model, flow_model="UnsupportedModel")
+            make_evidence_computation(mcmc, model, flow_model="UnsupportedModel")
 
     def test_training_proportion_too_small_for_chains(self, simple_mcmc_setup):
         """Test that training_proportion too small for num_chains raises ValueError."""
         mcmc, model, _ = simple_mcmc_setup
 
-        # With 10 chains, training_proportion=0.05 would give 0 training chains
+        # With 4 chains, training_proportion=0.05 would give 0 training chains.
         with pytest.raises(
             ValueError, match="training_proportion.*too small.*training chains"
         ):
-            EvidenceComputation(mcmc, model, training_proportion=0.05)
+            make_evidence_computation(mcmc, model, training_proportion=0.05)
 
     def test_run_basic(self, simple_mcmc_setup):
         """Test basic evidence computation."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
-        results = ec.run(epochs=50, verbose=False)
+        ec = make_evidence_computation(mcmc, model)
+        results = ec.run(epochs=N_FLOW_EPOCHS, verbose=False)
 
         # Check results structure
         assert isinstance(results, dict)
@@ -186,43 +213,45 @@ class TestEvidenceComputation:
         assert abs(results["ln_evidence"] + results["ln_inv_evidence"]) < 1e-6
 
         # Check dimensions
-        assert results["num_chains"] == 10
-        assert results["num_samples_per_chain"] == 500
+        assert results["num_chains"] == N_MCMC_CHAINS
+        assert results["num_samples_per_chain"] == N_MCMC_SAMPLES
         assert results["num_parameters"] == 2
 
-    @pytest.mark.parametrize("training_proportion", [0.3, 0.5, 0.7])
+    @pytest.mark.parametrize("training_proportion", [0.5, 0.7])
     def test_different_training_proportions(
         self, simple_mcmc_setup, training_proportion
     ):
         """Test evidence computation with different training proportions."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(
+        ec = make_evidence_computation(
             mcmc, model, training_proportion=training_proportion, log_level="error"
         )
-        results = ec.run(epochs=5, verbose=False)
+        chains_train, chains_infer = ec.split_data()
+        assert ec.chains is not None
+        train_ratio = chains_train.samples.shape[0] / ec.chains.samples.shape[0]
 
-        assert isinstance(results, dict)
-        assert "ln_evidence" in results
+        assert chains_infer is not None
+        assert abs(train_ratio - training_proportion) <= 0.25
 
     @pytest.mark.parametrize("temperature", [0.5, 0.8, 1.0])
     def test_different_temperatures(self, simple_mcmc_setup, temperature):
         """Test evidence computation with different temperatures."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(
+        ec = make_evidence_computation(
             mcmc, model, temperature=temperature, log_level="error"
         )
-        results = ec.run(epochs=5, verbose=False)
+        flow = ec._create_flow_model(ec.ndim)
 
-        assert isinstance(results, dict)
-        assert "ln_evidence" in results
+        assert ec.temperature == temperature
+        assert flow is not None
 
     def test_get_chains_before_compute(self, simple_mcmc_setup):
         """Test that get_chains raises error before run."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
 
         with pytest.raises(RuntimeError, match="Call run"):
             ec.get_chains()
@@ -231,7 +260,7 @@ class TestEvidenceComputation:
         """Test that get_flow_model raises error before run."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
 
         with pytest.raises(RuntimeError, match="Call run"):
             ec.get_flow_model()
@@ -240,7 +269,7 @@ class TestEvidenceComputation:
         """Test that get_evidence_object raises error before run."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
 
         with pytest.raises(RuntimeError, match="Call run"):
             ec.get_evidence_object()
@@ -249,8 +278,8 @@ class TestEvidenceComputation:
         """Test getter methods work after run."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
-        ec.run(epochs=5, verbose=False)
+        ec = make_evidence_computation(mcmc, model)
+        ec.run(epochs=N_FLOW_EPOCHS, verbose=False)
 
         # Test all getter methods
         chains = ec.get_chains()
@@ -266,8 +295,8 @@ class TestEvidenceComputation:
         """Test split_data method separately."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(
-            mcmc, model, training_proportion=0.6, log_level="error"
+        ec = make_evidence_computation(
+            mcmc, model, training_proportion=0.5, log_level="error"
         )
         chains_train, chains_infer = ec.split_data()
 
@@ -282,15 +311,15 @@ class TestEvidenceComputation:
         total_samples = ec.chains.samples.shape[0]
         train_samples = chains_train.samples.shape[0]
         train_ratio = train_samples / total_samples
-        assert 0.55 < train_ratio < 0.65  # Allow some tolerance
+        assert 0.45 < train_ratio < 0.55  # Allow some tolerance
 
     def test_fit_flow_method(self, simple_mcmc_setup):
         """Test fit_flow method separately."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
         ec.split_data()
-        ec.fit_flow(epochs=10, verbose=False)
+        ec.fit_flow(epochs=N_FLOW_EPOCHS, verbose=False)
 
         # Check that flow was created and trained
         assert ec.flow is not None
@@ -302,18 +331,18 @@ class TestEvidenceComputation:
         """Test that fit_flow raises error if split_data not called."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
 
         with pytest.raises(RuntimeError, match="Must call split_data"):
-            ec.fit_flow(epochs=10)
+            ec.fit_flow(epochs=N_FLOW_EPOCHS)
 
     def test_compute_ln_evidence_method(self, simple_mcmc_setup):
         """Test compute_ln_evidence method separately."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
         ec.split_data()
-        ec.fit_flow(epochs=10, verbose=False)
+        ec.fit_flow(epochs=N_FLOW_EPOCHS, verbose=False)
         results = ec.compute_ln_evidence()
 
         # Check results structure
@@ -322,14 +351,14 @@ class TestEvidenceComputation:
         assert "ln_inv_evidence" in results
         assert "error_lower" in results
         assert "error_upper" in results
-        assert results["num_chains"] == 10
+        assert results["num_chains"] == N_MCMC_CHAINS
         assert results["num_parameters"] == 2
 
     def test_compute_ln_evidence_without_fit_raises_error(self, simple_mcmc_setup):
         """Test that compute_ln_evidence raises error if fit_flow not called."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
         ec.split_data()
 
         with pytest.raises(RuntimeError, match="Must call split_data.*and fit_flow"):
@@ -339,7 +368,7 @@ class TestEvidenceComputation:
         """Test the modular workflow: split -> fit -> compute."""
         mcmc, model, _ = simple_mcmc_setup
 
-        ec = EvidenceComputation(mcmc, model, log_level="error")
+        ec = make_evidence_computation(mcmc, model)
 
         # Step 1: Split data
         chains_train, chains_infer = ec.split_data()
@@ -347,33 +376,29 @@ class TestEvidenceComputation:
         assert chains_infer is not None
 
         # Step 2: Fit flow
-        ec.fit_flow(epochs=10, verbose=False)
+        ec.fit_flow(epochs=N_FLOW_EPOCHS, verbose=False)
         assert ec.flow is not None
 
         # Step 3: Compute evidence
         results = ec.compute_ln_evidence()
         assert "ln_evidence" in results
 
-        # Verify consistency with convenience method
-        ec2 = EvidenceComputation(mcmc, model, log_level="error")
-        results2 = ec2.run(epochs=10, verbose=False)
-
-        # Both should produce similar results (may not be identical due to randomness)
-        assert abs(results["ln_evidence"] - results2["ln_evidence"]) < 5.0
+        assert not torch.isnan(torch.tensor(results["ln_evidence"]))
 
 
 class TestIntegration:
     """Integration tests for the full workflow."""
 
     def test_full_workflow(self):
-        """Test complete workflow from calibration to evidence computation."""
+        """Test calibration output can initialize evidence computation."""
         # Setup simulation
         sim = Projectile()
-        x = sim.sample_inputs(50)
+        pyro.set_rng_seed(1)
+        x = sim.sample_inputs(N_TRAINING_POINTS)
         y, _ = sim.forward_batch(x)
 
         # Train emulator
-        gp = GaussianProcess(x, y)
+        gp = GaussianProcess(x, y, epochs=GP_EPOCHS)
         gp.fit(x, y)
 
         # Run calibration
@@ -381,16 +406,23 @@ class TestIntegration:
         bc = BayesianCalibration(
             gp, sim.parameters_range, observations, 1.0, log_level="error"
         )
-        mcmc = bc.run_mcmc(warmup_steps=50, num_samples=100, num_chains=10)
+        mcmc = bc.run_mcmc(
+            warmup_steps=N_INTEGRATION_MCMC_WARMUP,
+            num_samples=N_INTEGRATION_MCMC_SAMPLES,
+            num_chains=N_INTEGRATION_MCMC_CHAINS,
+            sampler="hmc",
+            step_size=HMC_STEP_SIZE,
+            trajectory_length=HMC_TRAJECTORY_LENGTH,
+        )
 
-        # Compute evidence
-        ec = EvidenceComputation(mcmc, bc.model, log_level="error")
-        results = ec.run(epochs=5, verbose=False)
-
-        # Verify results
-        assert "ln_evidence" in results
-        assert isinstance(results["ln_evidence"], float)
-        assert not torch.isnan(torch.tensor(results["ln_evidence"]))
+        # Check that real calibration output is consumable by evidence computation.
+        ec = make_evidence_computation(mcmc, bc.model)
+        assert ec.samples.shape == (
+            N_INTEGRATION_MCMC_CHAINS,
+            N_INTEGRATION_MCMC_SAMPLES,
+            2,
+        )
+        assert not torch.isnan(ec.log_probs).any()
 
     def test_custom_flow_kwargs_rqspline(self, simple_mcmc_setup):
         """Test evidence computation with custom RQSpline flow parameters."""
@@ -398,34 +430,27 @@ class TestIntegration:
 
         # Custom parameters for RQSpline
         flow_kwargs = {
-            "n_layers": 12,
-            "n_bins": 16,
-            "hidden_size": [128, 128],
+            "n_layers": 2,
+            "n_bins": 8,
+            "hidden_size": [16, 16],
             "learning_rate": 0.0005,
         }
 
-        ec = EvidenceComputation(
+        ec = make_evidence_computation(
             mcmc, model, flow_kwargs=flow_kwargs, log_level="error"
         )
-        results = ec.run(epochs=10, verbose=False)
+        flow = ec._create_flow_model(ec.ndim)
 
-        # Verify results are valid
-        assert "ln_evidence" in results
-        assert isinstance(results["ln_evidence"], float)
-        assert not torch.isnan(torch.tensor(results["ln_evidence"]))
-        assert not torch.isinf(torch.tensor(results["ln_evidence"]))
-
-        # Verify flow was created with custom parameters
-        assert ec.flow is not None
+        assert flow is not None
 
     def test_flow_kwargs_override_defaults(self, simple_mcmc_setup):
         """Test that flow_kwargs override default parameters."""
         mcmc, model, _ = simple_mcmc_setup
 
         # Override standardize (default is True)
-        flow_kwargs = {"standardize": False, "n_layers": 4}
+        flow_kwargs = {"standardize": False, "n_layers": 2}
 
-        ec = EvidenceComputation(
+        ec = make_evidence_computation(
             mcmc, model, flow_kwargs=flow_kwargs, log_level="error"
         )
 
@@ -437,8 +462,3 @@ class TestIntegration:
         # Create flow and check it was configured
         flow = ec._create_flow_model(ec.ndim)
         assert flow is not None
-
-        # Run full computation to ensure it works
-        results = ec.run(epochs=10, verbose=False)
-        assert "ln_evidence" in results
-        assert isinstance(results["ln_evidence"], float)

--- a/tests/emulators/test_grads.py
+++ b/tests/emulators/test_grads.py
@@ -9,6 +9,7 @@ from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms.pca import PCATransform
 from autoemulate.transforms.standardize import StandardizeTransform
 from autoemulate.transforms.vae import VAETransform
+from tests.utils import transformed_full_covariance_warning_context
 
 X_TRANSFORMS = [[StandardizeTransform()]]
 Y_TRANSFORMS = [
@@ -100,7 +101,11 @@ def test_grads(
     em.fit(x, y)
 
     # Get predictions
-    mean, variance = em.predict_mean_and_variance(x2, with_grad=True)
+    warning_context = transformed_full_covariance_warning_context(
+        output_from_samples, full_covariance, y_transforms
+    )
+    with warning_context:
+        mean, variance = em.predict_mean_and_variance(x2, with_grad=True)
 
     # Check that mean requires gradients
     assert mean.requires_grad

--- a/tests/emulators/test_transformed.py
+++ b/tests/emulators/test_transformed.py
@@ -1,6 +1,4 @@
 import itertools
-import warnings
-from contextlib import contextmanager, nullcontext
 
 import pytest
 import torch
@@ -12,30 +10,9 @@ from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms import PCATransform, StandardizeTransform, VAETransform
 from autoemulate.transforms.base import AutoEmulateTransform
-from linear_operator.utils.warnings import NumericalWarning
-
-
-@contextmanager
-def _ignore_expected_psd_repairs():
-    """Ignore expected PSD repairs in transformed full-covariance tests."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=r"cov not p\.d\. - .*",
-            category=NumericalWarning,
-        )
-        yield
-
-
-def _prediction_warning_context(output_from_samples, full_covariance, y_transforms):
-    if (
-        full_covariance
-        and not output_from_samples
-        and y_transforms is not None
-        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
-    ):
-        return _ignore_expected_psd_repairs()
-    return nullcontext()
+from tests.utils import (
+    transformed_full_covariance_warning_context,
+)
 
 
 def get_pytest_param_yof(model, x_t, y_t, o, f):
@@ -108,7 +85,7 @@ def run_test(
     )
     em.fit(x, y)
 
-    warning_context = _prediction_warning_context(
+    warning_context = transformed_full_covariance_warning_context(
         output_from_samples, full_covariance, y_transforms
     )
     with warning_context:

--- a/tests/emulators/test_transformed.py
+++ b/tests/emulators/test_transformed.py
@@ -1,4 +1,6 @@
 import itertools
+import warnings
+from contextlib import contextmanager, nullcontext
 
 import pytest
 import torch
@@ -10,6 +12,30 @@ from autoemulate.emulators.gaussian_process.exact import GaussianProcess
 from autoemulate.emulators.transformed.base import TransformedEmulator
 from autoemulate.transforms import PCATransform, StandardizeTransform, VAETransform
 from autoemulate.transforms.base import AutoEmulateTransform
+from linear_operator.utils.warnings import NumericalWarning
+
+
+@contextmanager
+def _ignore_expected_psd_repairs():
+    """Ignore expected PSD repairs in transformed full-covariance tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cov not p\.d\. - .*",
+            category=NumericalWarning,
+        )
+        yield
+
+
+def _prediction_warning_context(output_from_samples, full_covariance, y_transforms):
+    if (
+        full_covariance
+        and not output_from_samples
+        and y_transforms is not None
+        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
+    ):
+        return _ignore_expected_psd_repairs()
+    return nullcontext()
 
 
 def get_pytest_param_yof(model, x_t, y_t, o, f):
@@ -81,49 +107,54 @@ def run_test(
         full_covariance=full_covariance,
     )
     em.fit(x, y)
-    y_pred = em.predict(x2)
-    if issubclass(model, ProbabilisticEmulator):
-        assert isinstance(y_pred, DistributionLike)
-        y_pred_mean = em.predict_mean(x2)
-        assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred_mean.requires_grad
-        y_pred_mean, y_pred_var = em.predict_mean_and_variance(x2)
-        assert isinstance(y_pred_var, TensorLike)
-        assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
-        assert y_pred_var.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred_mean.requires_grad
-        assert not y_pred_var.requires_grad
-    else:
-        assert isinstance(y_pred, TensorLike)
-        assert y_pred.shape == (x2.shape[0], y.shape[1])
-        assert not y_pred.requires_grad
 
-    if not test_grads:
-        return
-
-    # Test gradient support only for few targets case
-    if em.supports_grad:
-        y_pred_grad = em.predict(x2, with_grad=True)
+    warning_context = _prediction_warning_context(
+        output_from_samples, full_covariance, y_transforms
+    )
+    with warning_context:
+        y_pred = em.predict(x2)
         if issubclass(model, ProbabilisticEmulator):
-            assert isinstance(y_pred_grad, DistributionLike)
-            y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
-            assert y_pred_grad_mean.requires_grad
-            y_pred_grad_mean, y_pred_grad_var = em.predict_mean_and_variance(
-                x2, with_grad=True
-            )
-            assert isinstance(y_pred_grad_var, TensorLike)
-            assert y_pred_grad_mean.requires_grad
-            assert y_pred_grad_var.requires_grad
+            assert isinstance(y_pred, DistributionLike)
+            y_pred_mean = em.predict_mean(x2)
+            assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred_mean.requires_grad
+            y_pred_mean, y_pred_var = em.predict_mean_and_variance(x2)
+            assert isinstance(y_pred_var, TensorLike)
+            assert y_pred_mean.shape == (x2.shape[0], y.shape[1])
+            assert y_pred_var.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred_mean.requires_grad
+            assert not y_pred_var.requires_grad
         else:
-            assert isinstance(y_pred_grad, TensorLike)
-            assert y_pred_grad.requires_grad
-            y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
-            assert y_pred_grad_mean.requires_grad
-        return
+            assert isinstance(y_pred, TensorLike)
+            assert y_pred.shape == (x2.shape[0], y.shape[1])
+            assert not y_pred.requires_grad
 
-    # Test that gradients raise error when not supported
-    with pytest.raises(ValueError, match="Gradient calculation is not supported."):
-        em.predict(x2, with_grad=True)
+        if not test_grads:
+            return
+
+        # Test gradient support only for few targets case
+        if em.supports_grad:
+            y_pred_grad = em.predict(x2, with_grad=True)
+            if issubclass(model, ProbabilisticEmulator):
+                assert isinstance(y_pred_grad, DistributionLike)
+                y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
+                assert y_pred_grad_mean.requires_grad
+                y_pred_grad_mean, y_pred_grad_var = em.predict_mean_and_variance(
+                    x2, with_grad=True
+                )
+                assert isinstance(y_pred_grad_var, TensorLike)
+                assert y_pred_grad_mean.requires_grad
+                assert y_pred_grad_var.requires_grad
+            else:
+                assert isinstance(y_pred_grad, TensorLike)
+                assert y_pred_grad.requires_grad
+                y_pred_grad_mean = em.predict_mean(x2, with_grad=True)
+                assert y_pred_grad_mean.requires_grad
+            return
+
+        # Test that gradients raise error when not supported
+        with pytest.raises(ValueError, match="Gradient calculation is not supported."):
+            em.predict(x2, with_grad=True)
 
 
 @pytest.mark.parametrize(
@@ -264,6 +295,9 @@ def test_transformed_emulator_1000_targets(
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning"
+)
 def test_inverse_gaussian_and_sample_pca(sample_data_y2d, new_data_y2d):
     set_random_seed(0)
     x, y = sample_data_y2d
@@ -306,6 +340,9 @@ def test_inverse_gaussian_and_sample_pca(sample_data_y2d, new_data_y2d):
     assert torch.allclose(y_pred_cov, y_pred2_cov, rtol=5e-2)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:cov not p\\.d\\. - .*:linear_operator.utils.warnings.NumericalWarning"
+)
 def test_inverse_gaussian_and_sample_vae(sample_data_y2d, new_data_y2d):
     torch.manual_seed(0)
     x, y = sample_data_y2d

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -233,6 +233,8 @@ def test_sample(method):
     }
     sim = MockSimulator(param_bouns, ["var1", "var2"])
 
+    # Sobol needs a power-of-two count to keep its balance properties (SciPy warns
+    # otherwise); other methods are unconstrained.
     n_samples = 1024 if method == "sobol" else 1000
     samples = sim.sample_inputs(n_samples, method=method)
 

--- a/tests/simulations/test_base_simulator.py
+++ b/tests/simulations/test_base_simulator.py
@@ -233,7 +233,7 @@ def test_sample(method):
     }
     sim = MockSimulator(param_bouns, ["var1", "var2"])
 
-    n_samples = 1000
+    n_samples = 1024 if method == "sobol" else 1000
     samples = sim.sample_inputs(n_samples, method=method)
 
     assert isinstance(samples, TensorLike)

--- a/tests/transforms/test_transforms_utils.py
+++ b/tests/transforms/test_transforms_utils.py
@@ -1,19 +1,76 @@
+import warnings
+
 import pytest
 import torch
 from autoemulate.transforms.utils import make_positive_definite
+from linear_operator.utils.warnings import NumericalWarning
 
 
 @pytest.mark.parametrize("scale", [1e-6, 1.0, 1e6])
 def test_make_positive_definite(scale):
-    """Test that make_positive_definite can handle various cases of cov matrices."""
-
-    # Try large scale
+    """make_positive_definite handles a range of badly-scaled, non-p.d. matrices."""
     for dim in [5, 20, 100]:
-        # Batch of 1000 random covariance matrices
+        # Batch of 1000 random (non-symmetric, non-p.d.) matrices
         covs = torch.rand(1000, dim, dim) * scale
-        covs = make_positive_definite(covs, clamp_eigvals=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumericalWarning)
+            covs = make_positive_definite(covs, clamp_eigvals=True)
 
         for cov in covs:
             assert cov.shape == (dim, dim)
-            # Try cholesky decomposition to check if it's positive definite
+            # Cholesky decomposition succeeds iff the matrix is positive definite
             torch.linalg.cholesky(cov)
+
+
+def test_make_positive_definite_already_pd_is_unchanged():
+    """An already-p.d. matrix is returned untouched and without warnings."""
+    cov = torch.tensor([[2.0, 0.5], [0.5, 1.0]], dtype=torch.float64)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = make_positive_definite(cov)
+    assert out is cov
+
+
+def test_make_positive_definite_baseline_jitter_is_silent():
+    """Rounding-level non-p.d.-ness is repaired by the baseline jitter, silently."""
+    cov = torch.eye(4, dtype=torch.float64)
+    cov[0, 0] = -1e-10  # not p.d., but well within the baseline jitter
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = make_positive_definite(cov)
+    torch.linalg.cholesky(out)
+
+
+def test_make_positive_definite_material_jitter_warns_and_keeps_gradients():
+    """A material jitter warns; the result stays differentiable w.r.t. the input."""
+    x = torch.tensor(1.0, dtype=torch.float64, requires_grad=True)
+    # Diagonal with one (small) negative eigenvalue; the baseline jitter is too
+    # small to fix it, so the jitter has to escalate past it.
+    cov = torch.diag(torch.stack([x, -1e-5 * x]))
+    with pytest.warns(NumericalWarning, match="added"):
+        out = make_positive_definite(cov, max_tries=8)
+    torch.linalg.cholesky(out)
+    out.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad)
+
+
+def test_make_positive_definite_eigval_clamp_warns():
+    """The eigenvalue-clamping fallback warns."""
+    cov = torch.diag(torch.tensor([-1.0, 1.0, 1.0], dtype=torch.float64))
+    with pytest.warns(NumericalWarning, match="gradients"):
+        out = make_positive_definite(cov, clamp_eigvals=True)
+    torch.linalg.cholesky(out)
+
+
+def test_make_positive_definite_raises_without_clamp():
+    """Without eigenvalue clamping, an unrepairable matrix raises rather than warns."""
+    cov = torch.diag(torch.tensor([-1.0, 1.0, 1.0], dtype=torch.float64))
+    with pytest.raises(RuntimeError):
+        make_positive_definite(cov)
+
+
+def test_make_positive_definite_rejects_high_rank_tensors():
+    """Only 2D and 3D (batched) tensors are accepted."""
+    with pytest.raises(ValueError, match="2D or 3D"):
+        make_positive_definite(torch.zeros(2, 3, 3, 3))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,31 @@
+import warnings
+from contextlib import contextmanager, nullcontext
+
+from autoemulate.transforms import PCATransform, VAETransform
+from linear_operator.utils.warnings import NumericalWarning
+
+
+@contextmanager
+def ignore_expected_transformed_psd_repairs():
+    """Ignore expected PSD repairs in transformed full-covariance tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"cov not p\.d\. - .*",
+            category=NumericalWarning,
+        )
+        yield
+
+
+def transformed_full_covariance_warning_context(
+    output_from_samples, full_covariance, y_transforms
+):
+    """Return a warning context for expected transformed covariance repairs."""
+    if (
+        full_covariance
+        and not output_from_samples
+        and y_transforms is not None
+        and any(isinstance(t, PCATransform | VAETransform) for t in y_transforms)
+    ):
+        return ignore_expected_transformed_psd_repairs()
+    return nullcontext()


### PR DESCRIPTION
Merge after #990 as branched from there.

## Summary
- ~~tighten PSD warning handling and keep warnings local to tests that intentionally trigger numerical repairs~~ (included in #990)
- ~~ignore known MPS fallback warnings globally in pytest configuration~~ (included in #990)
- reduce slow calibration and evidence tests by reusing small fixtures, deterministic evidence samples, and short HMC settings

## Validation
- uv run ruff check tests/calibration/test_bayesian_calibration.py tests/calibration/test_evidence_computation.py
- uv run pyright tests/calibration/test_bayesian_calibration.py tests/calibration/test_evidence_computation.py
- uv run pytest tests/calibration/test_bayesian_calibration.py -q
- uv run pytest tests/calibration/test_evidence_computation.py -q
- uv run pytest tests/calibration/test_bayesian_calibration.py tests/calibration/test_evidence_computation.py -q

Refs #978