### PR TITLE
Fix failing test and new warnings

### DIFF
--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -9,6 +10,8 @@ from matplotlib.figure import Figure
 
 from autoemulate.core.types import DistributionLike, GaussianLike, NumpyLike, TensorLike
 from autoemulate.emulators.base import Emulator, PyTorchBackend
+
+_NON_INTERACTIVE_BACKENDS = {"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"}
 
 
 def display_figure(fig: Figure):
@@ -38,9 +41,18 @@ def display_figure(fig: Figure):
         # we don't show otherwise it will double plot
         plt.close(fig)
         return fig
-    # in terminal, show the plot
+
+    backend = mpl.get_backend().lower()
+    if any(
+        backend.endswith(non_interactive)
+        for non_interactive in _NON_INTERACTIVE_BACKENDS
+    ):
+        plt.close(fig)
+        return fig
+
+    # in terminal with an interactive backend, show the plot
+    fig.show()
     plt.close(fig)
-    plt.show()
     return fig
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,10 @@ filterwarnings = [
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
+    # Raised by Pyro on Python 3.10 when parsing a dependency docstring.
+    "ignore:invalid escape sequence.*:DeprecationWarning:pyro\\.ops\\.stats",
+    # Raised when harmonic imports TensorFlow Probability's JAX backend.
+    "ignore:jax\\.interpreters\\.xla\\.pytype_aval_mappings is deprecated\\..*:DeprecationWarning:tensorflow_probability\\.python\\.internal\\.backend\\.jax\\.ops",
     # PyTorch MPS backend capability fallbacks are backend noise in tests.
     "ignore:The operator .* is not currently supported on the MPS backend.*:UserWarning",
 ]

--- a/tests/calibration/test_evidence_computation.py
+++ b/tests/calibration/test_evidence_computation.py
@@ -52,7 +52,6 @@ def simple_model():
 
 def make_evidence_computation(mcmc, model, **kwargs):
     kwargs.setdefault("flow_kwargs", TEST_FLOW_KWARGS)
-    kwargs.setdefault("log_level", "error")
     return EvidenceComputation(mcmc, model, **kwargs)
 
 

--- a/tests/emulators/test_mlp.py
+++ b/tests/emulators/test_mlp.py
@@ -116,8 +116,6 @@ def test_mlp_docstring_no_additional():
         Number of parameters to predict per output dimension. Defaults to 1.
     random_seed: int | None
         Random seed for reproducibility. If None, no seed is set. Defaults to None.
-    deterministic: bool
-        Whether to use deterministic algorithms in PyTorch. Defaults to False.
     device: DeviceLike | None
         Device to run the model on (e.g., "cpu", "cuda", "mps"). Defaults to None.
     scheduler_cls: type[LRScheduler] | None
@@ -174,8 +172,6 @@ def test_mlp_docstring_with_args():
         Number of parameters to predict per output dimension. Defaults to 1.
     random_seed: int | None
         Random seed for reproducibility. If None, no seed is set. Defaults to None.
-    deterministic: bool
-        Whether to use deterministic algorithms in PyTorch. Defaults to False.
     device: DeviceLike | None
         Device to run the model on (e.g., "cpu", "cuda", "mps"). Defaults to None.
     scheduler_cls: type[LRScheduler] | None


### PR DESCRIPTION
This PR:
- Fixes a failing test following change in #996
- Fixes warnings from deprecated `log_level` raised due to use in tests
- Fix deprecation warnings for Python 3.10
- Fix plot warning for non-interactive backends