### PR TITLE
Error on warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra dev --extra spatiotemporal
+          # --compile-bytecode is needed to trigger the DeprecationWarning from
+          # https://github.com/pyro-ppl/pyro/issues/3450, which pytest can't
+          # intercept. If we don't trigger this now, then pytest will promote the
+          # warning to an error and CI will fail.
+          uv sync --extra dev --extra spatiotemporal --compile-bytecode
 
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,9 +113,7 @@ relative_files = true
 source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
-# https://github.com/pyro-ppl/pyro/issues/3450: has to be ignored at the Python
-# level since the warning is raised before pytest can apply its own filters
-addopts = "--ignore=v0 -Wignore::DeprecationWarning:pyro.ops.stats"
+addopts = "--ignore=v0"
 # These suppress only test output; runtime warnings still reach users.
 filterwarnings = [
     # Promote all unfiltered warnings to errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,14 +113,16 @@ relative_files = true
 source = [".", "/tmp"]
 
 [tool.pytest.ini_options]
-addopts = "--ignore=v0"
+# https://github.com/pyro-ppl/pyro/issues/3450: has to be ignored at the Python
+# level since the warning is raised before pytest can apply its own filters
+addopts = "--ignore=v0 -Wignore::DeprecationWarning:pyro.ops.stats"
 # These suppress only test output; runtime warnings still reach users.
 filterwarnings = [
+    # Promote all unfiltered warnings to errors
+    "error",
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",
-    # Raised by Pyro on Python 3.10 when parsing a dependency docstring.
-    "ignore:invalid escape sequence.*:DeprecationWarning:pyro\\.ops\\.stats",
     # Raised when harmonic imports TensorFlow Probability's JAX backend.
     "ignore:jax\\.interpreters\\.xla\\.pytype_aval_mappings is deprecated\\..*:DeprecationWarning:tensorflow_probability\\.python\\.internal\\.backend\\.jax\\.ops",
     # PyTorch MPS backend capability fallbacks are backend noise in tests.


### PR DESCRIPTION
Closes #1007

This actually took me a long time to figure out. Here are the facts:

- There's only one warning in CI right now. It's a `DeprecationWarning`, which stems from an [invalid escape sequence in pyro](https://github.com/pyro-ppl/pyro/issues/3450) (which is effectively unmaintained; the last release was 2 years ago -- so while the true solution is to fix it upstream, this probably won't happen).

- This is triggered when a module is first imported (when Python compiles the bytecode, the `.pyc` files inside `__pycache__`).

- Because this happens prior to Pytest being loaded, it's actually not possible to catch it with the `filterwarnings` options (see e.g. https://github.com/pytest-dev/pytest/issues/13145)

I think there's only one reliable way to stop it from ruining CI, which is to compile the bytecode before running Pytest. The `--compile-bytecode` flag is easy to enforce in CI, but I think it's important to mention in the docs, given that this can be confusing (e.g. if someone does `uv run pytest` before compiling bytecode they will get an error),

I tried to suppress it with `uv run python -Wignore::DeprecationWarning:pyro.ops.stats -m pytest ...`, as suggested in the pytest issue above, but I couldn't get it to work :/

