### PR TITLE
Remove link to old AE website

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ You can find the project documentation [here](https://alan-turing-institute.gith
 
 
 - The AutoEmulate project is run out of the [Alan Turing Institute](https://www.turing.ac.uk/).
-- Visit [autoemulate.com](https://www.autoemulate.com/) to learn more.
 - Feel free to reach out to us at [aiphys@turing.ac.uk](mailto:aiphys@turing.ac.uk) for queries about AutoEmulate or ideas for collaboration.
 - We have also published a paper in [The Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.07626). 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@
 `AutoEmulate` is a Python library that makes it easy to create accurate and efficient emulators for complex simulations. Under the hood, the package runs a complete machine learning pipeline to compare and optimise a wide range of models, and provides functions for downstream tasks like prediction, sensitivity analysis and calibration.
 
 This website provides detailed documentation on how to use `AutoEmulate`, including installation instructions, tutorials, and a comprehensive API reference.
-For an overview of the project, checkout [autoemulate.com](https://alan-turing-institute.github.io/astroemulate/).
 
 ## 🔗 Quick Links
 


### PR DESCRIPTION
We plan to replace autoemulate.com with the overarching AutoX site.