### PR TITLE
restructure Section 5 SEIR cells to match Sections 1-4 style

### DIFF
--- a/docs/tutorials/tasks/03_seir_bayes_calibration.ipynb
+++ b/docs/tutorials/tasks/03_seir_bayes_calibration.ipynb
@@ -444,46 +444,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5. Extending to an SEIR epidemic model\n",
+    "### 5.1 Simulate data\n",
     "\n",
-    "The Epidemic simulator used above implements a simple SIR model with two parameters (beta, gamma) and returns the peak infection rate as a summary statistic. In this final step, we extend the tutorial to a slightly richer SEIR model by adding an exposed compartment and an incubation rate.\n",
-    "\n",
-    "We first define a new SEIRSimulator that subclasses Simulator. The underlying SEIR dynamics are:\n",
-    "\n",
-    "● S(t): susceptible\n",
-    "\n",
-    "● E(t): exposed (infected but not yet infectious)\n",
-    "\n",
-    "● I(t): infectious\n",
-    "\n",
-    "● R(t): recovered\n",
-    "\n",
-    "with parameters:\n",
-    "\n",
-    "● beta: transmission rate per day\n",
-    "\n",
-    "● gamma: recovery rate per day\n",
-    "\n",
-    "● sigma: incubation rate per day\n",
-    "\n",
-    "The ODE system is integrated with solve_ivp, and we again return the peak infection fraction max_t I(t) / N so that the output is comparable to the original SIR example.\n",
-    "\n",
-    "As before, we:\n",
-    "\n",
-    "1. Simulate data.\n",
-    "We use SEIRSimulator to draw a set of input parameters [beta, gamma, sigma], run the SEIR model, and visualise how the peak infection rate varies over the parameter space.\n",
-    "\n",
-    "2. Generate observations.\n",
-    "We pick a “true” parameter triple (beta, gamma, sigma), run the SEIR simulator once to obtain a reference peak infection rate, and then add Gaussian noise to create multiple noisy observations, stored as observations = {\"infection_rate\": ...}.\n",
-    "\n",
-    "3. Calibrate with the simulator (Pyro).\n",
-    "We specify Uniform priors over beta, gamma, and sigma, call the SEIR simulator inside a Pyro model, and run MCMC using a random walk kernel. This gives posterior samples for all three parameters directly from the simulator.\n",
-    "\n",
-    "4. Train an emulator and recalibrate.\n",
-    "We then train a GaussianProcessRBF emulator on a design of SEIR simulations using AutoEmulate, and perform Bayesian calibration again using BayesianCalibration. This replaces repeated simulator calls with the GP surrogate, which is more scalable for expensive models.\n",
-    "\n",
-    "5. Compare posteriors and diagnostics.\n",
-    "Finally, we convert the simulator– and emulator–based MCMC runs to ArviZ / GetDist objects, plot the joint posteriors, posterior predictive checks, and trace plots, and verify that the emulator reproduces the simulator posterior for the SEIR model while being much cheaper to evaluate"
+    "We use SEIRSimulator to draw a set of input parameters [beta, gamma, sigma], run the SEIR model, and visualise how the peak infection rate varies over the parameter space."
    ]
   },
   {
@@ -505,8 +468,22 @@
     "\n",
     "simulator = SEIRSimulator(show_progress_bar=False)\n",
     "x = simulator.sample_inputs(1000)\n",
-    "y, _ = simulator.forward_batch(x)\n",
-    "\n",
+    "y, _ = simulator.forward_batch(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we plot the simulated data, coloured by the peak infection rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Plot\n",
     "transmission_rate = x[:, 0]\n",
     "recovery_rate = x[:, 1]\n",
@@ -518,8 +495,24 @@
     "plt.ylabel('Recovery rate (gamma)')\n",
     "plt.colorbar(sc, label=\"Peak infection rate\")\n",
     "plt.title(\"SEIR Model Simulation\")\n",
-    "plt.show()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Generate observations\n",
     "\n",
+    "We pick a \"true\" parameter triple (beta, gamma, sigma), run the SEIR simulator once to obtain a reference peak infection rate, and then add Gaussian noise to create multiple noisy observations, stored as observations = {\"infection_rate\": ...}."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Step 2: Observed data\n",
     "true_beta = 0.3\n",
     "true_gamma = 0.15\n",
@@ -531,8 +524,24 @@
     "stdev = 0.05\n",
     "noise = torch.normal(mean=0, std=stdev, size=(n_obs,))\n",
     "observed_infection_rates = true_infection_rate[0] + noise\n",
-    "observations = {\"infection_rate\": observed_infection_rates}\n",
+    "observations = {\"infection_rate\": observed_infection_rates}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 Calibrate with the simulator (Pyro)\n",
     "\n",
+    "We specify Uniform priors over beta, gamma, and sigma, call the SEIR simulator inside a Pyro model, and run MCMC using a random walk kernel. This gives posterior samples for all three parameters directly from the simulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Step 3: Calibrate with simulator using Pyro\n",
     "import pyro.distributions as dist\n",
     "from pyro.infer import MCMC\n",
@@ -554,22 +563,67 @@
     "\n",
     "kernel = RandomWalkKernel(model, init_step_size=2.5)\n",
     "mcmc_sim = MCMC(kernel, warmup_steps=1500, num_samples=15000, num_chains=1) #might have to increase warmup syeps and num of samples for convergence\n",
-    "mcmc_sim.run()\n",
-    "\n",
+    "mcmc_sim.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we plot the posterior samples for `beta` and `gamma`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sim_samples = mcmc_sim.get_samples()\n",
     "plt.scatter(sim_samples['beta'], sim_samples['gamma'], alpha=0.5)\n",
     "plt.xlabel('Beta')\n",
     "plt.ylabel('Gamma')\n",
     "plt.title('Simulator Posterior Samples')\n",
-    "plt.show()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.4 Train an emulator and recalibrate\n",
     "\n",
+    "We then train a GaussianProcessRBF emulator on a design of SEIR simulations using AutoEmulate, and perform Bayesian calibration again using BayesianCalibration. This replaces repeated simulator calls with the GP surrogate, which is more scalable for expensive models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Step 4: Train Emulator and Calibrate\n",
     "from autoemulate.core.compare import AutoEmulate\n",
     "from autoemulate.emulators import GaussianProcessRBF\n",
     "from autoemulate.calibration.bayes import BayesianCalibration\n",
     "\n",
     "ae = AutoEmulate(x, y, models=[GaussianProcessRBF], model_params={}, show_progress_bar=False)\n",
-    "ae.summarise()\n",
+    "ae.summarise()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We extract the best emulator and pass it, along with the parameter ranges and observations, into `BayesianCalibration`. The `observation_noise` is the variance of the Gaussian likelihood."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gp = ae.best_result().model\n",
     "\n",
     "bc = BayesianCalibration(\n",
@@ -577,17 +631,93 @@
     "    simulator.parameters_range,\n",
     "    observations,\n",
     "    observation_noise=stdev**2,\n",
-    ")\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run MCMC against the emulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "mcmc_emu = bc.run_mcmc(warmup_steps=250, num_samples=1000, num_chains=2)\n",
-    "mcmc_emu.summary()\n",
+    "mcmc_emu.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.5 Compare posteriors and diagnostics\n",
     "\n",
+    "Finally, we convert the simulator&ndash; and emulator&ndash;based MCMC runs to ArviZ / GetDist objects, plot the joint posteriors, posterior predictive checks, and trace plots, and verify that the emulator reproduces the simulator posterior for the SEIR model while being much cheaper to evaluate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Step 5: Plotting\n",
     "az_data = bc.to_arviz(mcmc_emu, posterior_predictive=True)\n",
-    "_ = az.plot_pair(az_data, kind='kde')\n",
-    "_ = az.plot_ppc(az_data)\n",
-    "_ = az.plot_trace(az_data, figsize=(20, 8))\n",
+    "_ = az.plot_pair(az_data, kind='kde')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Posterior predictive check &mdash; the posterior predictive samples should overlap the observed data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = az.plot_ppc(az_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Trace plot for MCMC diagnostics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = az.plot_trace(az_data, figsize=(20, 8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.6 Comparing posteriors with GetDist\n",
     "\n",
+    "Below we Compare the simulator and emulator posteriors with GetDist. Both should concentrate near the true parameter values (shown as markers)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Step 6: Compare Posterior Distributions\n",
     "sim_data = BayesianCalibration.to_getdist(mcmc_sim, label=\"Simulator\")\n",
     "emu_data = arviz_to_mcsamples(az_data, dataset_label=\"Emulator\")\n",


### PR DESCRIPTION
Restructures Section 5 (SEIR model) cells to match the markdown/code cell alternating pattern used in Sections 1–4. No code changes, documentation only.