### PR TITLE
Add FESTIM links to case studies

### DIFF
--- a/case_studies/README.md
+++ b/case_studies/README.md
@@ -10,5 +10,5 @@ Each subdirectory provides data, scripts, and documentation relevant to a specif
 
 ## External examples
 
-- **hydrogen transport**: The [FESTIM](https://festim-workshop.readthedocs.io/en/latest/intro.html) simulator documentation includes examples of using AutoEmulate for [surrogate modelling](https://festim-workshop.readthedocs.io/en/latest/content/applications/surrogate.html) and [active learning](https://festim-workshop.readthedocs.io/en/latest/content/applications/active_learning.html).
+- **Hydrogen transport**: The [FESTIM](https://festim-workshop.readthedocs.io/en/latest/intro.html) simulator documentation includes examples of using AutoEmulate for [surrogate modelling](https://festim-workshop.readthedocs.io/en/latest/content/applications/surrogate.html) and [active learning](https://festim-workshop.readthedocs.io/en/latest/content/applications/active_learning.html).
 

--- a/case_studies/README.md
+++ b/case_studies/README.md
@@ -1,10 +1,14 @@
 # Case Studies
 
-This directory contains example case studies demonstrating the use of the AutoEmulate framework for various scientific and engineering problems. Each subdirectory provides data, scripts, and documentation relevant to a specific application area.
+This directory contains example case studies demonstrating the use of the AutoEmulate framework for various scientific and engineering problems.
 
 ## Overview
-- **patient_calibration/**: Demonstrates cardiovascular model calibration using the Naghavi Model from ModularCirc. Shows end-to-end workflow including sensitivity analysis, history matching, and Bayesian calibration for blood pressure dynamics in the left ventricle.
 
-Additional case studies may be added in the future to showcase more applications and methodologies.
+Each subdirectory provides data, scripts, and documentation relevant to a specific application area.
 
-For details on each case study, refer to the README or documentation within the respective subdirectory.
+- **patient_calibration/**: Demonstrates cardiovascular model calibration using the Naghavi Model from [ModularCirc](https://github.com/alan-turing-institute/ModularCirc). Shows end-to-end workflow including sensitivity analysis, history matching, and Bayesian calibration for blood pressure dynamics in the left ventricle.
+
+## External examples
+
+- **hydrogen transport**: The [FESTIM](https://festim-workshop.readthedocs.io/en/latest/intro.html) simulator documentation includes examples of using AutoEmulate for [surrogate modelling](https://festim-workshop.readthedocs.io/en/latest/content/applications/surrogate.html) and [active learning](https://festim-workshop.readthedocs.io/en/latest/content/applications/active_learning.html).
+


### PR DESCRIPTION
The FESTIM simulator docs include AutoEmulate examples so here we add them to our case studies README.