### PR TITLE
Fix #928: Replace ±2σ with 95% predictive intervals in plots

### DIFF
--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -855,7 +855,9 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
     ):
         """
         Plot predicted means (and variances) against observations for all outputs.
-        When variance is available, a 95% predictive interval (mean ± 1.96σ) is shown.
+
+        When variance is available, a 95% predictive interval (mean +/- 1.96 * std)
+        is shown.
 
         Parameters
         ----------

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -16,6 +16,7 @@ from autoemulate.core.logging_config import _resolve_show_progress_bar, get_logg
 from autoemulate.core.metrics import R2, Metric, MetricParams, get_metric, get_metrics
 from autoemulate.core.model_selection import bootstrap, evaluate
 from autoemulate.core.plotting import (
+    PREDICTION_INTERVAL_Z,
     calculate_subplot_layout,
     create_and_plot_slice,
     display_figure,
@@ -925,7 +926,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                 axs[i].errorbar(
                     test_y[:, i],
                     y_pred[:, i],
-                    yerr=2 * y_std[:, i],
+                    yerr=PREDICTION_INTERVAL_Z * y_std[:, i],
                     fmt="none",
                     alpha=0.4,
                     capsize=3,
@@ -944,7 +945,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
             )
             axs[i].set_title(output_names[i])
             axs[i].set_xlabel("True values")
-            axs[i].set_ylabel("Predicted values ±2\u03c3")
+            axs[i].set_ylabel("Predicted values (95% PI)")
         plt.tight_layout()
 
         if figsize is not None:

--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -855,6 +855,7 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
     ):
         """
         Plot predicted means (and variances) against observations for all outputs.
+        When variance is available, a 95% predictive interval (mean ± 1.96σ) is shown.
 
         Parameters
         ----------

--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -84,7 +84,7 @@ def plot_xy(
         An array of predictions.
     y_variance: NumpyLike | None
         An optional array of predictive variances. When provided, a 95%
-        predictive interval (mean ± 1.96σ) is displayed around predictions.
+        predictive interval (mean +/- 1.96 * std) is displayed around predictions.
     ax: Axes | None
         An optional matplotlib Axes object to plot on.
     title: str
@@ -196,7 +196,7 @@ def plot_xy(
     # Place R² just below the legend
     if legend:
         # Get the bounding box of the legend in axes coordinates
-        bbox = legend.get_window_extent(ax.figure.canvas.get_renderer())  # pyright: ignore[reportAttributeAccessIssue]
+        bbox = legend.get_window_extent(ax.figure.canvas.get_renderer())  # pyright: ignore[reportAttributeAccessIssue, reportOptionalMemberAccess]
         inv = ax.transAxes.inverted()
         bbox_axes = bbox.transformed(inv)
         # Place the text just below the legend

--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -13,6 +13,9 @@ from autoemulate.emulators.base import Emulator, PyTorchBackend
 
 _NON_INTERACTIVE_BACKENDS = {"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"}
 
+# z-score for the default predictive interval coverage (norm.ppf(0.975) ≈ 1.96 for 95%)
+PREDICTION_INTERVAL_Z = 1.96
+
 
 def display_figure(fig: Figure):
     """
@@ -118,14 +121,13 @@ def plot_xy(
             ax.errorbar(
                 x_sorted,
                 y_pred_sorted,
-                yerr=2 * y_std,
+                yerr=PREDICTION_INTERVAL_Z * y_std,
                 fmt="o",
                 color=pred_points_color,
                 elinewidth=2,
                 capsize=3,
                 alpha=0.5,
-                # use unicode for sigma
-                label="pred. (±2\u03c3)",
+                label="pred. (95% PI)",
             )
             ax.scatter(
                 x_sorted,
@@ -138,11 +140,11 @@ def plot_xy(
         else:
             ax.fill_between(
                 x_sorted,
-                y_pred_sorted - 2 * y_std,
-                y_pred_sorted + 2 * y_std,
+                y_pred_sorted - PREDICTION_INTERVAL_Z * y_std,
+                y_pred_sorted + PREDICTION_INTERVAL_Z * y_std,
                 color=pred_points_color,
                 alpha=0.2,
-                label="±2\u03c3",
+                label="95% PI",
             )
             ax.plot(
                 x_sorted,

--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -7,14 +7,15 @@ import torch
 from IPython.core.getipython import get_ipython
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from scipy.stats import norm
 
 from autoemulate.core.types import DistributionLike, GaussianLike, NumpyLike, TensorLike
 from autoemulate.emulators.base import Emulator, PyTorchBackend
 
 _NON_INTERACTIVE_BACKENDS = {"agg", "cairo", "pdf", "pgf", "ps", "svg", "template"}
 
-# z-score for the default predictive interval coverage (norm.ppf(0.975) ≈ 1.96 for 95%)
-PREDICTION_INTERVAL_Z = 1.96
+# z-score for the default predictive interval coverage (≈ 1.96 for 95% interval)
+PREDICTION_INTERVAL_Z = norm.ppf(0.975)
 
 
 def display_figure(fig: Figure):

--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -83,7 +83,8 @@ def plot_xy(
     y_pred: NumpyLike
         An array of predictions.
     y_variance: NumpyLike | None
-        An optional array of predictive variances.
+        An optional array of predictive variances. When provided, a 95%
+        predictive interval (mean ± 1.96σ) is displayed around predictions.
     ax: Axes | None
         An optional matplotlib Axes object to plot on.
     title: str

--- a/tests/core/test_plotting.py
+++ b/tests/core/test_plotting.py
@@ -83,7 +83,7 @@ def test_plot_xy_fill_interval_width():
     fig, ax = plt.subplots()
     plotting.plot_xy(X, y, y_pred, y_variance, ax=ax, r2_score=0.9, error_style="fill")
 
-    verts = ax.collections[0].get_paths()[0].vertices
+    verts = np.asarray(ax.collections[0].get_paths()[0].vertices)
     band_width = verts[:, 1].max() - verts[:, 1].min()
     assert np.isclose(band_width, 2 * plotting.PREDICTION_INTERVAL_Z * y_std)
 

--- a/tests/core/test_plotting.py
+++ b/tests/core/test_plotting.py
@@ -53,6 +53,41 @@ def test_plot_xy():
     assert len(ax.collections) > 0
 
 
+def test_prediction_interval_z_constant():
+    assert plotting.PREDICTION_INTERVAL_Z == 1.96
+
+
+def test_plot_xy_bars_interval_width():
+    X = np.linspace(0, 5, 10)
+    y = X.copy()
+    y_pred = np.full(10, 2.5)
+    y_variance = np.full(10, 4.0)
+    y_std = np.sqrt(4.0)
+
+    fig, ax = plt.subplots()
+    plotting.plot_xy(X, y, y_pred, y_variance, ax=ax, r2_score=0.9)
+
+    _, _, barlinecols = ax.containers[0]
+    seg = barlinecols[0].get_segments()[0]
+    half_width = abs(seg[1][1] - seg[0][1]) / 2
+    assert np.isclose(half_width, plotting.PREDICTION_INTERVAL_Z * y_std)
+
+
+def test_plot_xy_fill_interval_width():
+    X = np.linspace(0, 5, 10)
+    y = X.copy()
+    y_pred = np.full(10, 2.5)  # constant so band is flat
+    y_variance = np.full(10, 4.0)
+    y_std = np.sqrt(4.0)
+
+    fig, ax = plt.subplots()
+    plotting.plot_xy(X, y, y_pred, y_variance, ax=ax, r2_score=0.9, error_style="fill")
+
+    verts = ax.collections[0].get_paths()[0].vertices
+    band_width = verts[:, 1].max() - verts[:, 1].min()
+    assert np.isclose(band_width, 2 * plotting.PREDICTION_INTERVAL_Z * y_std)
+
+
 @pytest.mark.parametrize(
     ("n_plots", "n_cols", "expected"),
     [

--- a/tests/core/test_plotting.py
+++ b/tests/core/test_plotting.py
@@ -53,10 +53,6 @@ def test_plot_xy():
     assert len(ax.collections) > 0
 
 
-def test_prediction_interval_z_constant():
-    assert plotting.PREDICTION_INTERVAL_Z == 1.96
-
-
 def test_plot_xy_bars_interval_width():
     X = np.linspace(0, 5, 10)
     y = X.copy()


### PR DESCRIPTION
Replaces 2 * y_std (±2σ) with 1.96 * y_std (95% PI) in all plots and updates labels accordingly.

- Adds PREDICTION_INTERVAL_Z = 1.96 constant in plotting.py and v0/plotting.py so future coverage changes are a single-line edit
- Updates plot_xy (bars + fill) and plot_preds in compare.py
- Updates docstrings
- Adds 3 tests verifying the interval width