### PR TITLE
Fix docstring parameters that do not match the signatures

### DIFF
--- a/autoemulate/calibration/bayes.py
+++ b/autoemulate/calibration/bayes.py
@@ -42,7 +42,7 @@ class BayesianCalibration(TorchDeviceMixin, BayesianMixin):
         ----------
         emulator: Emulator
             Fitted Emulator object.
-        parameters_range : dict[str, tuple[float, float]]
+        parameter_range : dict[str, tuple[float, float]]
             A dictionary mapping input parameter names to their (min, max) ranges.
         observations: dict[str, TensorLike]
             A dictionary of observations for each output.
@@ -70,10 +70,10 @@ class BayesianCalibration(TorchDeviceMixin, BayesianMixin):
         Notes
         -----
         The model assumes:
-        - Uniform priors for calibrated parameters (bounds given by `parameters_range`)
+        - Uniform priors for calibrated parameters (bounds given by `parameter_range`)
         - Gaussian likelihood with no correlation between outputs
         All non-calibrated parameters are set to a constant value. This is chosen as the
-        midpoint value of `parameters_range`.
+        midpoint value of `parameter_range`.
         """
         TorchDeviceMixin.__init__(self, device=device)
         self.parameter_range = parameter_range

--- a/autoemulate/core/results.py
+++ b/autoemulate/core/results.py
@@ -185,11 +185,8 @@ class Results:
         metric: str | Metric | None
             The name of the metric to use for comparison. If None, uses the first
             available metric found in the results. The metric should exist in the
-            test_metrics of the results.
-        metric_maximize: bool | None
-            Whether higher values are better for the metric. If None, defaults to True
-            (assumes higher is better). Set to False for metrics like RMSE or MAE where
-            lower is better.
+            test_metrics of the results. Whether higher or lower values are better is
+            taken from the metric itself (`Metric.maximize`).
 
         Returns
         -------

--- a/autoemulate/core/sensitivity_analysis.py
+++ b/autoemulate/core/sensitivity_analysis.py
@@ -1236,20 +1236,20 @@ def _plot_sa_heatmap(
 
     Parameters
     ----------
-    results: pd.DataFrame
+    si_df: pd.DataFrame
         Sensitivity index dataframe with columns ['index', 'parameter',
         'output', 'value'].
     index: str
         The type of sensitivity index to plot (e.g., 'ST').
-    top_n: int | None
-        Number of top parameters to include. If None, returns all. Defaults to
-        None.
+    parameters: list[str]
+        Parameters to include, in the order they should appear as columns.
     cmap: str
         Matplotlib colormap. Defaults to 'coolwarm'.
     normalize: bool
-        Wheterto normalize values to [0, 1]. Defaults to True.
-    figsize: tuple | None
-        Figure size as (width, height) in inches. Defaults to None.
+        Whether to normalize values to [0, 1]. Defaults to True.
+    fig_size: tuple | None
+        Figure size as (width, height) in inches. If None, it is derived from
+        the heatmap layout. Defaults to None.
 
     Returns
     -------

--- a/autoemulate/emulators/gaussian_process/exact.py
+++ b/autoemulate/emulators/gaussian_process/exact.py
@@ -81,6 +81,12 @@ class GaussianProcess(GaussianProcessEmulator, gpytorch.models.ExactGP):
             Input features, expected to be a 2D tensor of shape (n_samples, n_features).
         y: TensorLike
             Target values, expected to be a 2D tensor of shape (n_samples, n_tasks).
+        standardize_x: bool
+            Whether to standardize the input features with a `StandardizeTransform`
+            before fitting. Defaults to False.
+        standardize_y: bool
+            Whether to standardize the target values with a `StandardizeTransform`
+            before fitting. Defaults to True.
         likelihood_cls: type[MultitaskGaussianLikelihood]
             Likelihood class to use for the model. Defaults to
             `MultitaskGaussianLikelihood`.
@@ -370,6 +376,12 @@ class GaussianProcessCorrelated(GaussianProcess):
             Input features, expected to be a 2D tensor of shape (n_samples, n_features).
         y: TensorLike
             Target values, expected to be a 2D tensor of shape (n_samples, n_tasks).
+        standardize_x: bool
+            Whether to standardize the input features with a `StandardizeTransform`
+            before fitting. Defaults to False.
+        standardize_y: bool
+            Whether to standardize the target values with a `StandardizeTransform`
+            before fitting. Defaults to True.
         likelihood_cls: type[MultitaskGaussianLikelihood]
             Likelihood class to use for the model. Defaults to
             `MultitaskGaussianLikelihood`.
@@ -389,9 +401,7 @@ class GaussianProcessCorrelated(GaussianProcess):
             False, it will return the posterior distribution over the modelled function.
             Defaults to False.
         epochs: int
-            Number of training epochs.
-        activation: type[nn.Module]
-            Activation function to use in the model. Defaults to `nn.ReLU`.
+            Number of training epochs. Defaults to 50.
         lr: float
             Learning rate for the optimizer. Defaults to 2e-1.
         early_stopping: EarlyStopping | None
@@ -401,7 +411,8 @@ class GaussianProcessCorrelated(GaussianProcess):
             GPU). Defaults to None.
         scheduler_cls: type[LRScheduler] | None
             Learning rate scheduler class. If None, no scheduler is used. Defaults to
-        scheduler_params: dict
+            None.
+        scheduler_params: dict | None
             Additional keyword arguments for the learning rate scheduler.
         """
         # Init device

--- a/autoemulate/learners/base.py
+++ b/autoemulate/learners/base.py
@@ -290,7 +290,7 @@ class Active(Learner):
 
         Parameters
         ----------
-        *arg: TensorLike or None
+        x: TensorLike or None
             Optional input samples.
 
         Returns


### PR DESCRIPTION
## What this fixes

Seven docstring blocks across five files name a parameter the function does not take, or leave a real one undocumented. All of them are reachable from the public API, so copying the documented name gives a `TypeError`.

| Where | Documented | Actual signature |
|---|---|---|
| `BayesianCalibration.__init__` | `parameters_range` (×3, incl. two mentions in Notes) | `parameter_range` |
| `Results.best_result` | `metric_maximize` | no such parameter |
| `GaussianProcessCorrelated.__init__` | `activation` | no such parameter |
| `GaussianProcess.__init__`, `GaussianProcessCorrelated.__init__` | — | `standardize_x`, `standardize_y` undocumented |
| `GaussianProcessCorrelated.__init__` | `scheduler_cls` description ends at "Defaults to" | base class has the same text ending "None." |
| `_plot_sa_heatmap` | `results`, `top_n`, `figsize` | `si_df`, `parameters`, `fig_size` |
| `Learner.query` | `*arg` | `x` |

A few notes on the individual ones:

**`parameters_range` vs `parameter_range`.** Both spellings genuinely exist in the codebase — `core/plotting.py` and `core/compare.py` do take `parameters_range`, which is probably where the docstring came from. Only `BayesianCalibration.__init__` is inconsistent with its own signature (`self.parameter_range = parameter_range`, and `calibration_params` defaults to `parameter_range.keys()`), so I changed the docstring rather than the argument.

**`metric_maximize`.** The behaviour it describes moved into the metric object — `best_result` branches on `metric_selected.maximize`. I folded that into the `metric` description instead of just deleting the block.

**`activation`.** No `nn.Module` activation is constructed anywhere in `GaussianProcessCorrelated`; the mean and covariance modules come from `mean_module_fn` / `covar_module_fn`.

**`standardize_x` / `standardize_y`.** Real arguments in both constructors (`self.x_transform = StandardizeTransform() if standardize_x else None`), with different defaults from each other (`False` and `True`), and undocumented in both. Wording taken from `StandardizeTransform`.

Docstrings only — no behaviour change, nothing outside docstrings touched. `ruff format --check` and `ruff check` are clean on the five files.

I did not touch the `__post_init__` docstrings in `learners/stream.py`, which document `x_train` / `y_train` as dataclass fields rather than arguments — that reads deliberate, but say the word if you would like them aligned too.
