### PR TITLE
Skip failed simulator queries in active learners

### DIFF
--- a/autoemulate/learners/base.py
+++ b/autoemulate/learners/base.py
@@ -162,24 +162,26 @@ class Active(Learner):
 
         if x is not None:
             # If x is not, we skip the point (typically for Stream learners)
-            logger.info("Appending new training data and refitting emulator.")
             y_true = self.simulator.forward(x)
-            assert isinstance(y_true, TensorLike)
-            self.x_train = torch.cat([self.x_train, x])
-            self.y_train = torch.cat([self.y_train, y_true])
-            if self.fit_from_reinitialized:
-                self.emulator = fit_from_reinitialized(
-                    self.x_train,
-                    self.y_train,
-                    emulator=self.emulator,
-                    device=self.emulator.device,
-                )
+            if y_true is None:
+                logger.warning("Simulation failed. Skipping queried point.")
             else:
-                self.emulator.fit(self.x_train, self.y_train)
-            self.mse.update(y_pred, y_true)
-            self.r2.update(y_pred, y_true)
-            self.n_queries += 1
-            logger.info("Training data updated. Total queries: %s", self.n_queries)
+                logger.info("Appending new training data and refitting emulator.")
+                self.x_train = torch.cat([self.x_train, x])
+                self.y_train = torch.cat([self.y_train, y_true])
+                if self.fit_from_reinitialized:
+                    self.emulator = fit_from_reinitialized(
+                        self.x_train,
+                        self.y_train,
+                        emulator=self.emulator,
+                        device=self.emulator.device,
+                    )
+                else:
+                    self.emulator.fit(self.x_train, self.y_train)
+                self.mse.update(y_pred, y_true)
+                self.r2.update(y_pred, y_true)
+                self.n_queries += 1
+                logger.info("Training data updated. Total queries: %s", self.n_queries)
 
         # Only compute once we have ≥2 labeled points
         if self.n_queries >= 2:

--- a/tests/learners/test_learners.py
+++ b/tests/learners/test_learners.py
@@ -16,6 +16,12 @@ class Sin(Simulator):
         return torch.sin(x)
 
 
+class FailingSin(Simulator):
+    def _forward(self, x: torch.Tensor) -> None:
+        del x
+        return None
+
+
 def learners(
     *, simulator: Simulator, n_initial_samples: int, adaptive_only: bool
 ) -> Iterable:
@@ -144,6 +150,27 @@ def run_experiment(
             metrics.append(dict(name=learner.__class__.__name__, **learner.metrics))
             summary.append(dict(name=learner.__class__.__name__, **learner.summary))
     return metrics, summary
+
+
+def test_failed_simulator_query_is_skipped():
+    simulator = FailingSin(parameters_range={"x": (0, 5.0)}, output_names=["y"])
+    x_train = torch.tensor([[0.0], [1.0]])
+    y_train = torch.sin(x_train)
+    learner = stream.Random(
+        simulator=simulator,
+        emulator=GaussianProcessRBF(x_train, y_train, lr=0.001),
+        x_train=x_train.clone(),
+        y_train=y_train.clone(),
+        p_query=1.0,
+        fit_from_reinitialized=False,
+    )
+
+    learner.fit(torch.tensor([[2.0]]), random_seed=0)
+
+    assert torch.equal(learner.x_train, x_train)
+    assert torch.equal(learner.y_train, y_train)
+    assert learner.n_queries == 0
+    assert learner.metrics["n_queries"] == [0]
 
 
 def test_learners_sin():


### PR DESCRIPTION
Fixes #930.

## Summary

Handle the simulator's documented failure result in `Active.fit()` instead of asserting that every queried simulation succeeds.

When `Simulator.forward()` returns `None`, the learner now logs the failure and skips that queried point without:

- appending it to the training set
- refitting the emulator
- updating prediction error metrics
- incrementing `n_queries`

A regression test forces a query against a simulator that returns `None` and verifies the learner's training data and query count remain unchanged.

## Why

`Simulator.forward(..., allow_failures=True)` intentionally returns `None` on failed simulations. `Active.fit()` previously converted that tolerated failure into an `AssertionError`.

## Testing

A focused regression test was added under `tests/learners/test_learners.py`. The full repository test suite was not executed locally, so this is opened as a draft for CI validation.