### PR TITLE
Remove obsolete Black development dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ After writing new code or modifying existing code, please make sure to:
 
 * write [numpy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html).
 * write tests in the `tests/` directory using [pytest](https://docs.pytest.org/en/7.4.x/).
-* format the code using [black](https://github.com/psf/black)
+* format the code using [Ruff](https://docs.astral.sh/ruff/formatter/).
 
 It would be great if you could also [update the documentation](https://alan-turing-institute.github.io/autoemulate/community/contributing-docs.html) to reflect the changes you've made. If you plan to add a new emulator have a look at the [contributing emulators docs](https://alan-turing-institute.github.io/autoemulate/community/contributing-emulators.html).
 
@@ -87,7 +87,7 @@ We run [`pre-commit`](https://pre-commit.com/) in CI for every pull request, so 
    pre-commit run --all-files
    ```
 
-If a hook makes changes, simply re-stage the affected files and run the command again until you get a `Passed` message. For hooks that fail with an error, follow the hint printed in the terminal (for example, formatting with Black or fixing lint) and then re-run `pre-commit run --all-files`.
+If a hook makes changes, simply re-stage the affected files and run the command again until you get a `Passed` message. For hooks that fail with an error, follow the hint printed in the terminal (for example, formatting with Ruff or fixing lint) and then re-run `pre-commit run --all-files`.
 
 ### 4. Open a Pull Request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dev = [
     "furo>=2023.9.10",
     "sphinx-copybutton>=0.5.2",
     "sphinx-autodoc-typehints>=1.24.0",
-    "black>=23.10.1",
     "pre-commit>=3.5.0",
     "jupyter-book>=1.0.0,<2.0.0",
     "pytest-cov>=4.1.0",


### PR DESCRIPTION
## Summary

Remove Black from the development dependency set and update contributor guidance to use Ruff for formatting.

## Changes

- remove `black` from the `dev` optional dependencies
- replace the remaining Black formatting references in `CONTRIBUTING.md` with Ruff

## Rationale

AutoEmulate's enforced formatting and lint configuration uses Ruff, so keeping Black in the development environment and contributor instructions is redundant and misleading.

Closes #1026.