### PR TITLE
Promote unexpected test warnings to errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
     env:
       TURN_OFF_MPS_IF_RUNNING_CI: 1
       MPLBACKEND: Agg
+      PYTHONWARNINGS: "ignore:invalid escape sequence:DeprecationWarning:pyro.ops.stats"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ source = [".", "/tmp"]
 addopts = "--ignore=v0"
 # These suppress only test output; runtime warnings still reach users.
 filterwarnings = [
+    "error",
     # Raised by PyTorch (via gpytorch) - not actionable here.
     # Remove if dependencies no longer calling `torch.jit.script`.
     "ignore:`torch\\.jit\\.script` is deprecated\\..*:DeprecationWarning",


### PR DESCRIPTION
## Summary

Make AutoEmulate CI fail on unexpected Python warnings while preserving the existing allow-list for known dependency and backend warnings.

## Changes

- add `error` as the default pytest warning policy
- suppress the known Pyro import-time `DeprecationWarning` through `PYTHONWARNINGS`, before pytest loads its warning filters

## Validation

The `PYTHONWARNINGS` filter was independently checked against the same warning message, category, and module pattern.

Closes #1007.