### PR TITLE
Filter model parameters by emulator signature

### DIFF
--- a/autoemulate/core/compare.py
+++ b/autoemulate/core/compare.py
@@ -465,10 +465,15 @@ class AutoEmulate(ConversionMixin, TorchDeviceMixin, Results):
                                     for param_name, param in init_sig.parameters.items()
                                     if param_name in model_cls.get_tune_params()
                                 }
-                                # Overwrite defaults with user-supplied values
+                                # Apply only user parameters accepted by this model.
+                                compatible_model_params = {
+                                    param_name: value
+                                    for param_name, value in self.model_params.items()
+                                    if param_name in init_sig.parameters
+                                }
                                 best_params_for_this_model = {
                                     **default_params,
-                                    **self.model_params,
+                                    **compatible_model_params,
                                 }
 
                             logger.debug(

--- a/tests/core/test_compare.py
+++ b/tests/core/test_compare.py
@@ -114,6 +114,23 @@ def test_ae_no_tuning_fix_params(sample_data_for_ae_compare):
     assert ae.best_result().model.model.posterior_predictive is True  # pyright: ignore[reportAttributeAccessIssue]
 
 
+def test_ae_no_tuning_ignores_incompatible_model_params(
+    sample_data_for_ae_compare,
+):
+    """Model-specific params should not break other models in a comparison."""
+    x, y = sample_data_for_ae_compare
+    ae = AutoEmulate(
+        x,
+        y,
+        models=["GaussianProcessRBF", "RandomForest"],
+        model_params={"posterior_predictive": True},
+    )
+
+    assert len(ae.results) == 2
+    assert ae.get_result(0).model.model.posterior_predictive is True  # pyright: ignore[reportAttributeAccessIssue]
+    assert "posterior_predictive" not in ae.get_result(1).params
+
+
 def test_get_model_subset():
     """Test getting a subset of models based on pytroch and probabilistic flags."""
 


### PR DESCRIPTION
Fixes #921.

## Summary

When tuning is disabled, apply only user-supplied `model_params` that are accepted by each emulator's constructor.

This allows a shared `model_params` dictionary to contain parameters for one model without causing unrelated models in the same comparison to fail.

- preserve each model's existing default tune parameters
- filter user overrides against that model's `__init__` signature
- add a mixed GaussianProcessRBF/RandomForest regression test showing `posterior_predictive` is applied only to the GP model

## Testing

- `tests/core/test_compare.py`: 3 targeted tests passed
- ruff: passed
- ruff format: passed
- pyright: passed