### PR TITLE
Plot 95% prediction interval width on surfaces

### DIFF
--- a/autoemulate/core/plotting.py
+++ b/autoemulate/core/plotting.py
@@ -373,16 +373,17 @@ def _plot_2d_slice_with_fixed_params(
     fig.colorbar(im0, ax=ax)
 
     if var_2d is not None:
-        # Plot variance
+        # Plot the full width of the 95% predictive interval
+        interval_width_2d = 2 * float(PREDICTION_INTERVAL_Z) * torch.sqrt(var_2d)
         ax = axs[0, 1]
         im1 = ax.imshow(
-            var_2d.T,
+            interval_width_2d.T,
             origin="lower",
             aspect="auto",
             extent=[x_min, x_max, y_min, y_max],
             cmap="magma",
         )
-        ax.set_title("predicted variance")
+        ax.set_title("95% prediction interval width")
         ax.set_xlabel(param_names[0])
         ax.set_ylabel(param_names[1])
         fig.colorbar(im1, ax=ax)

--- a/tests/core/test_plotting.py
+++ b/tests/core/test_plotting.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import torch
 from autoemulate.core import plotting
 from autoemulate.emulators.polynomials import PolynomialRegression
 from autoemulate.emulators.random_forest import RandomForest
@@ -82,6 +83,34 @@ def test_plot_xy_fill_interval_width():
     verts = np.asarray(ax.collections[0].get_paths()[0].vertices)
     band_width = verts[:, 1].max() - verts[:, 1].min()
     assert np.isclose(band_width, 2 * plotting.PREDICTION_INTERVAL_Z * y_std)
+
+
+def test_plot_2d_slice_uses_95_percent_interval_width():
+    mean = torch.zeros(4)
+    variance = torch.tensor([1.0, 4.0, 9.0, 16.0])
+    grid = torch.meshgrid(
+        torch.arange(2, dtype=torch.float32),
+        torch.arange(2, dtype=torch.float32),
+        indexing="ij",
+    )
+
+    _, axes = plotting._plot_2d_slice_with_fixed_params(
+        mean,
+        variance,
+        grid,
+        ["x", "y"],
+        lower=None,
+        upper=None,
+    )
+
+    plotted_width = np.asarray(axes[0, 1].images[0].get_array())
+    expected_width = (
+        2
+        * plotting.PREDICTION_INTERVAL_Z
+        * torch.sqrt(variance.reshape(2, 2)).T.numpy()
+    )
+    assert np.allclose(plotted_width, expected_width)
+    assert axes[0, 1].get_title() == "95% prediction interval width"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Replace the variance heatmap in 2D surface slices with the full width of the 95% predictive interval (`2 * z_0.975 * sqrt(variance)`), so uncertainty is displayed on the same scale as the model output and consistently with the 95% intervals used elsewhere.

Adds regression coverage that checks the exact plotted interval width and the updated plot title.

Closes #931

## Tests

Added coverage in `tests/core/test_plotting.py` for the 95% prediction interval width calculation.