### PR TITLE
Authenticate Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -59,6 +63,7 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+          use_oidc: true
 
       #   # Clean python cache files
       # - name: Clean cache files


### PR DESCRIPTION
## Summary

- Grants the CI workflow `id-token: write` while keeping repository contents read-only.
- Enables Codecov v5 OIDC authentication for the existing coverage upload.
- Avoids requiring a long-lived `CODECOV_TOKEN` secret for uploads from protected `main`.

Addresses the remaining coverage-upload item in #876.

## Tests

Workflow-only change. The Codecov step remains restricted to pushes to `main` on Ubuntu with Python 3.12.